### PR TITLE
clang doesn't really support -static on darwin

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -15,7 +15,9 @@ OBJS = ldpl.o
 SOURCE = ldpl.cpp
 OUT = ldpl
 FLAGS = -g -c -Wall -std=gnu++11 -fpermissive -DVERSION=$(VERSION) -DSTANDARD=$(LDPLSTD) -DCOMPILEDATE='"$(shell date)"'
-LFLAGS = -static-libgcc -static-libstdc++ 
+ifneq ($(shell uname -s),Darwin)
+	LFLAGS = -static-libgcc -static-libstdc++ 
+endif
 
 all: $(OBJS)
 	$(CXX) -g $(OBJS) -o $(OUT) $(LFLAGS)


### PR DESCRIPTION
On macOS 10.14.1:
```
$ make
awk -f lib-to-string.awk ldpl_lib.cpp > ldpl_included_lib.cpp
c++ -g -c -Wall -std=gnu++11 -fpermissive -DVERSION='"2.0.7"'   -DSTANDARD=19         -DCOMPILEDATE='"Tue Mar 12 22:23:30 PDT 2019"' ldpl.cpp
c++ -g ldpl.o -o ldpl -static-libgcc -static-libstdc++ 
clang: error: unsupported option '-static-libgcc'
make: *** [all] Error 1
```
clang has a `-static` option, but using it fails with `ld: library not found for -lcrt0.o`. 

[From developer.apple.com](https://developer.apple.com/library/archive/qa/qa1118/_index.html#//apple_ref/doc/uid/DTS10001666). 

> Apple does not support statically linked binaries on Mac OS X. A statically linked binary assumes binary compatibility at the kernel system call interface, and we do not make any guarantees on that front. Rather, we strive to ensure binary compatibility in each dynamically linked system library and framework.

I removed the -static flags and built a binary that works on both my laptop and another mac. Not sure if there's a better flag or way to do it. 
