### PR TITLE
include the \ in escape codes

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -206,14 +206,14 @@ void tokenize(string & line, unsigned int line_num, vector<string> & tokens, str
             {
                 char next_letter = line[++i];
                 switch(next_letter) 
-		{
-			case '\\': case '"': case '0':
-			case 'a': case 'b': case 't': case 'n': 
-			case 'v': case 'f': case 'r': case 'e': 
-			    current_token += "\\" + string(1, next_letter);
-			    break;
-			default: 
-			    error("unknown escape sequence (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+                {
+                    case '\\': case '"': case '0':
+                    case 'a': case 'b': case 't': case 'n': 
+                    case 'v': case 'f': case 'r': case 'e': 
+                        current_token += "\\" + string(1, next_letter);
+                    break;
+                    default: 
+                        error("unknown escape sequence (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
                 }
             }
             else error("\\ found alone (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
@@ -1805,14 +1805,14 @@ void split_vector(string & line, queue<string> & tokens)
             {
                 char next_letter = line[++i];
                 switch(next_letter) 
-		{
-			case '\\': case '"': case '0':
-			case 'a': case 'b': case 't': case 'n': 
-			case 'v': case 'f': case 'r': case 'e': 
-			    current_token += "\\" + string(1, next_letter);
-			    break;
-			default: 
-			    error("unknown escape sequence on a VECTOR access `" + current_token + "` in: " + line);
+                {
+                    case '\\': case '"': case '0':
+                    case 'a': case 'b': case 't': case 'n': 
+                    case 'v': case 'f': case 'r': case 'e': 
+                        current_token += "\\" + string(1, next_letter);
+                    break;
+                    default: 
+                        error("unknown escape sequence on a VECTOR access `" + current_token + "` in: " + line);
                 }
             }
             else error("\\ found alone on a VECTOR access.");

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -205,14 +205,15 @@ void tokenize(string & line, unsigned int line_num, vector<string> & tokens, str
             if(i < line.size() - 1)
             {
                 char next_letter = line[++i];
-                switch(next_letter) {
-                case '\\': case '"': case '0':
-                case 'a': case 'b': case 't': case 'n': 
-                case 'v': case 'f': case 'r': case 'e': 
-                    current_token += "\\" + string(1, next_letter);
-                    break;
-                default: 
-                    error("unknown escape sequence (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+                switch(next_letter) 
+		{
+			case '\\': case '"': case '0':
+			case 'a': case 'b': case 't': case 'n': 
+			case 'v': case 'f': case 'r': case 'e': 
+			    current_token += "\\" + string(1, next_letter);
+			    break;
+			default: 
+			    error("unknown escape sequence (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
                 }
             }
             else error("\\ found alone (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
@@ -1803,14 +1804,15 @@ void split_vector(string & line, queue<string> & tokens)
             if(i < line.size() - 1)
             {
                 char next_letter = line[++i];
-                switch(next_letter) {
-                case '\\': case '"': case '0':
-                case 'a': case 'b': case 't': case 'n': 
-                case 'v': case 'f': case 'r': case 'e': 
-                    current_token += "\\" + string(1, next_letter);
-                    break;
-                default: 
-                    error("unknown escape sequence on a VECTOR access `" + current_token + "` in: " + line);
+                switch(next_letter) 
+		{
+			case '\\': case '"': case '0':
+			case 'a': case 'b': case 't': case 'n': 
+			case 'v': case 'f': case 'r': case 'e': 
+			    current_token += "\\" + string(1, next_letter);
+			    break;
+			default: 
+			    error("unknown escape sequence on a VECTOR access `" + current_token + "` in: " + line);
                 }
             }
             else error("\\ found alone on a VECTOR access.");

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -205,18 +205,15 @@ void tokenize(string & line, unsigned int line_num, vector<string> & tokens, str
             if(i < line.size() - 1)
             {
                 char next_letter = line[++i];
-                if(next_letter == '\\' || next_letter == '"') current_token += next_letter;
-                //TODO sacar esto
-                else if(next_letter == 'a') current_token += "\\a";
-                else if(next_letter == 'b') current_token += "\\b";
-                else if(next_letter == 't') current_token += "\\t";
-                else if(next_letter == 'n') current_token += "\\n";
-                else if(next_letter == 'v') current_token += "\\v";
-                else if(next_letter == 'f') current_token += "\\f";
-                else if(next_letter == 'r') current_token += "\\r";
-                else if(next_letter == 'e') current_token += "\\e";
-                else if(next_letter == '0') current_token += "\\0";
-                //else error("unknown escape sequence (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+                switch(next_letter) {
+                case '\\': case '"': case '0':
+                case 'a': case 'b': case 't': case 'n': 
+                case 'v': case 'f': case 'r': case 'e': 
+                    current_token += "\\" + string(1, next_letter);
+                    break;
+                default: 
+                    error("unknown escape sequence (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+                }
             }
             else error("\\ found alone (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         }
@@ -1806,8 +1803,15 @@ void split_vector(string & line, queue<string> & tokens)
             if(i < line.size() - 1)
             {
                 char next_letter = line[++i];
-                if(next_letter == '\\' || next_letter == '"') current_token += next_letter;
-                else error("unknown escape sequence on a VECTOR access.");
+                switch(next_letter) {
+                case '\\': case '"': case '0':
+                case 'a': case 'b': case 't': case 'n': 
+                case 'v': case 'f': case 'r': case 'e': 
+                    current_token += "\\" + string(1, next_letter);
+                    break;
+                default: 
+                    error("unknown escape sequence on a VECTOR access `" + current_token + "` in: " + line);
+                }
             }
             else error("\\ found alone on a VECTOR access.");
         }


### PR DESCRIPTION
I was having issues with using `\n` and friends, and I think it's because the tokenizer wasn't passing something along. 

Sorry about the coding style, you can test this using this program:

```
$ cat escape.ldpl
PROCEDURE:
display "\t\e[33mi\e[32mn \e[31mt\e[34me\e[35mc\e[36mh\e[37mn\e[1m\e[31mi\e[32mc\e[33mo\e[34ml\e[35mo\e[36mu\e[37mr\e[0m\r\n" 
```

On master:

```
$ ldpl escape.ldpl
LDPL Error: unknown escape sequence on a VECTOR access.
```

Should work better in a modern terminal with this patch. 
