### PR TITLE
Add operator for v:"key"

### DIFF
--- a/src/ldpl_included_lib.cpp
+++ b/src/ldpl_included_lib.cpp
@@ -15,6 +15,9 @@ void add_ldpllib(compiler_state & state){
     state.add_var_code("");
     state.add_var_code("struct ldpl_num_vector{");
     state.add_var_code("    map<string, ldpl_number> inner_map;");
+    state.add_var_code("    ldpl_number& operator [] (const char* i) {");
+    state.add_var_code("        return inner_map[string(i)];");
+    state.add_var_code("    }");
     state.add_var_code("    ldpl_number operator [] (string & i) const {");
     state.add_var_code("        return inner_map.at(i);");
     state.add_var_code("    }");
@@ -34,6 +37,9 @@ void add_ldpllib(compiler_state & state){
     state.add_var_code("");
     state.add_var_code("struct ldpl_str_vector{");
     state.add_var_code("    map<string, string> inner_map;");
+    state.add_var_code("    string& operator [] (const char* i) {");
+    state.add_var_code("        return inner_map[string(i)];");
+    state.add_var_code("    }");
     state.add_var_code("    string operator [] (string & i) const {");
     state.add_var_code("        return inner_map.at(i);");
     state.add_var_code("    }");

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -14,6 +14,9 @@ using namespace std;
 
 struct ldpl_num_vector{
     map<string, ldpl_number> inner_map;
+    ldpl_number& operator [] (const char* i) {
+        return inner_map[string(i)];
+    }
     ldpl_number operator [] (string & i) const {
         return inner_map.at(i);
     }
@@ -33,6 +36,9 @@ struct ldpl_num_vector{
 
 struct ldpl_str_vector{
     map<string, string> inner_map;
+    string& operator [] (const char* i) {
+        return inner_map[string(i)];
+    }
     string operator [] (string & i) const {
         return inner_map.at(i);
     }


### PR DESCRIPTION
This script errors on master with `ldpl-temp.cpp:218:6: error: no viable overloaded operator[] for type
      'ldpl_str_vector'` but works with this PR:

```COBOL
DATA:
v is text vector
z is number vector

PROCEDURE:
store "Bart" in v:"name"
display v:"name" crlf

store 123 in z:"header"
store 987 in z:"footer"
display z:"footer"
```

Adding operator overloads fixes it for me but I'm not sure if there is a better way to go from literals to strings in C++. 
