### PR TITLE
Fix the broken vector keys fix

### DIFF
--- a/src/ldpl_included_lib.cpp
+++ b/src/ldpl_included_lib.cpp
@@ -30,6 +30,9 @@ void add_ldpllib(compiler_state & state){
     state.add_var_code("    ldpl_number& operator [] (ldpl_number i) {");
     state.add_var_code("        return inner_map[to_string(i)];");
     state.add_var_code("    }");
+    state.add_var_code("    ldpl_number& operator [] (int i) {");
+    state.add_var_code("        return inner_map[to_string(i)];");
+    state.add_var_code("    }");
     state.add_var_code("    ldpl_number length() {");
     state.add_var_code("        return (int) inner_map.size();");
     state.add_var_code("    }");
@@ -50,6 +53,9 @@ void add_ldpllib(compiler_state & state){
     state.add_var_code("        return inner_map.at(to_string(i));");
     state.add_var_code("    }");
     state.add_var_code("    string& operator [] (ldpl_number i) {");
+    state.add_var_code("        return inner_map[to_string(i)];");
+    state.add_var_code("    }");
+    state.add_var_code("    string& operator [] (int i) {");
     state.add_var_code("        return inner_map[to_string(i)];");
     state.add_var_code("    }");
     state.add_var_code("    ldpl_number length() {");

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -29,6 +29,9 @@ struct ldpl_num_vector{
     ldpl_number& operator [] (ldpl_number i) {
         return inner_map[to_string(i)];
     }
+    ldpl_number& operator [] (int i) {
+        return inner_map[to_string(i)];
+    }
     ldpl_number length() {
         return (int) inner_map.size();
     }
@@ -49,6 +52,9 @@ struct ldpl_str_vector{
         return inner_map.at(to_string(i));
     }
     string& operator [] (ldpl_number i) {
+        return inner_map[to_string(i)];
+    }
+    string& operator [] (int i) {
         return inner_map[to_string(i)];
     }
     ldpl_number length() {


### PR DESCRIPTION
This is a fix for the bug introduced in #20. It looks like the compiler was casting ints to ldpl_numbers before, but with the char* arg introduced it couldn't do the implicit cast anymore. So adding an int arg operator fixes it and catches all three cases of a string literal, whole number, and ldpl_number. But I don't know if other casting issues will arise here. 