### PR TITLE
Fix for literal string index

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -246,7 +246,14 @@ void capitalize_tokens(vector<string> & tokens)
 {
     for(string & token : tokens)
     {
-            if(!is_number(token) && !is_string(token))
+            if(is_vector_index(token))
+            {
+                for(char & l : token){
+                    if (l == ':') break;
+                    l = toupper(l);
+                }
+            }
+            else if(!is_number(token) && !is_string(token))
             {
                 for(char & l : token){
                     l = toupper(l);
@@ -1717,6 +1724,11 @@ bool is_natural(string number){
 
 bool is_string(string & token){
     return (token.size() >= 2 && token[0] == '"' && token[token.size()-1] == '"');
+}
+
+bool is_vector_index(string & token)
+{
+    return token.size() >= 2 && token[0] != '"' && token[token.size()-1] == '"';
 }
 
 bool is_num_vector(string & token, compiler_state & state)

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -62,6 +62,7 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
 bool is_number (string number);
 bool is_natural (string number);
 bool is_string(string & token);
+bool is_vector_index(string & token);
 bool is_num_var(string & token, compiler_state & state);
 bool is_txt_var(string & token, compiler_state & state);
 bool is_variable(string & token, compiler_state & state);


### PR DESCRIPTION
Sorry for all the spam today :)  While poking around vector index, I found what I think is a bug. The strings are being uppercased by the tokenizer, eg `list:"bob"` is becoming `LIST:"BOB"`. So you can't have both list:"bob" and list:"BOB", but you can still do list:x where x is "bob" to access a lowercase version. The standard says `myVector:"hello" #Stores 1 in the subindex "hello" of myVector` so I think the bug is in the tokenizer doing the uppercasing, so that's what I changed.

Here's a program to demonstrate:

```cobol
DATA:
v is text vector
z is number vector
x is text

PROCEDURE:
store "i" in x
store 1 in v:"i"
store 2 in v:"I"

display v:x crlf
display v:"i" crlf
display v:"I" crlf
```

Should see "1 1 2", not "2 2". 