### PR TITLE
Enforce all numbers to use the same type

### DIFF
--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -30,7 +30,7 @@ struct ldpl_num_vector{
         return inner_map[to_string(i)];
     }
     ldpl_number& operator [] (int i) {
-        return inner_map[to_string(i)];
+        return inner_map[to_string(ldpl_number(i))];
     }
     ldpl_number length() {
         return (int) inner_map.size();
@@ -55,7 +55,7 @@ struct ldpl_str_vector{
         return inner_map[to_string(i)];
     }
     string& operator [] (int i) {
-        return inner_map[to_string(i)];
+        return inner_map[to_string(ldpl_number(i))];
     }
     ldpl_number length() {
         return (int) inner_map.size();


### PR DESCRIPTION
I think the `to_string()` was producing something different for ints and the number type, so casting them all to the same type fixed the quine for me.

However I couldn't get any warnings on Linux even when the quine was broken so I'm not sure if this will fix the issue you mentioned in #22. What compiler are you using? I have `gcc (GCC) 8.2.1 20190131`. 