### PR TITLE
Change VECTOR C++ implementation to unordered_map and simplify it

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -58,7 +58,7 @@ int main(int argc, const char* argv[])
     state.variables["ARGC"] = 1;
     state.add_var_code("ldpl_number "+fix_identifier("ARGC", true)+";");
     state.variables["ARGV"] = 4;
-    state.add_var_code("ldpl_str_vector "+fix_identifier("ARGV", true)+";");
+    state.add_var_code("ldpl_vector<string> "+fix_identifier("ARGV", true)+";");
     state.add_code("for(int i = 1; i < argc; ++i)");
     state.add_code(fix_identifier("ARGV", true) + "[i-1] = argv[i];");
     state.add_code(fix_identifier("ARGC", true)+" = argc - 1;");
@@ -317,7 +317,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         else
             error("Duplicate declaration for variable " + tokens[0] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_var_code("ldpl_num_vector " + fix_identifier(tokens[0], true) + ";");
+        state.add_var_code("ldpl_vector<ldpl_number> " + fix_identifier(tokens[0], true) + ";");
         return;
     }
     if(line_like("$name IS TEXT VECTOR", tokens, state))
@@ -330,7 +330,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         else
             error("Duplicate declaration for variable " + tokens[0] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_var_code("ldpl_str_vector " + fix_identifier(tokens[0], true) + ";");
+        state.add_var_code("ldpl_vector<string> " + fix_identifier(tokens[0], true) + ";");
         return;
     }
     if(line_like("DISPLAY $display", tokens, state))

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <limits>
 #include <limits.h>
-#include <map>
+#include <unordered_map>
 #include <stdlib.h>
 
 #define NVM_FLOAT_EPSILON 0.00000001
@@ -12,53 +12,20 @@
 
 using namespace std;
 
-struct ldpl_num_vector{
-    map<string, ldpl_number> inner_map;
-    ldpl_number& operator [] (const char* i) {
-        return inner_map[string(i)];
-    }
-    ldpl_number operator [] (string & i) const {
-        return inner_map.at(i);
-    }
-    ldpl_number& operator [] (string & i) {
-        return inner_map[i];
-    }
-    ldpl_number operator [] (ldpl_number i) const {
-        return inner_map.at(to_string(i));
-    }
-    ldpl_number& operator [] (ldpl_number i) {
-        return inner_map[to_string(i)];
-    }
-    ldpl_number& operator [] (int i) {
-        return inner_map[to_string(ldpl_number(i))];
-    }
-    ldpl_number length() {
-        return (int) inner_map.size();
-    }
-};
+template<typename T>
+struct ldpl_vector {
+    unordered_map<string, T> inner_map;
 
-struct ldpl_str_vector{
-    map<string, string> inner_map;
-    string& operator [] (const char* i) {
-        return inner_map[string(i)];
-    }
-    string operator [] (string & i) const {
-        return inner_map.at(i);
-    }
-    string& operator [] (string & i) {
+    T& operator [] (const string& i) {
         return inner_map[i];
     }
-    string operator [] (ldpl_number i) const {
-        return inner_map.at(to_string(i));
-    }
-    string& operator [] (ldpl_number i) {
+
+    T& operator [] (ldpl_number i) {
         return inner_map[to_string(i)];
     }
-    string& operator [] (int i) {
-        return inner_map[to_string(ldpl_number(i))];
-    }
+
     ldpl_number length() {
-        return (int) inner_map.size();
+        return inner_map.size();
     }
 };
 


### PR DESCRIPTION
LDPL does not care about the order of the elements in a map so we can use unordered_map which is much faster for the average case. There were also many unnecessary overloads since most of them can be implicitly converted.