### PR TITLE
-v, --version, -h, or --help take priority

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -8,11 +8,29 @@
 //Show internal representation
 bool show_ir = false;
 
+template <typename T>
+static bool contains(vector<T> const& vec, T const& val)
+{
+    return vec.end() != find(vec.begin(), vec.end(), val);
+}
+
+template <typename T>
+static bool contains_any(vector<T> const& vec, vector<T> vals)
+{
+    for (auto const& v : vals)
+    {
+        if (contains(vec, v))
+            return true;
+    }
+    return false;
+}
+
 int main(int argc, const char* argv[])
 {
     //Get command line arguments as string vector
     vector<string> args(argv + 1, argv + argc);
-    if(args.size() == 1 && (args[0] == "-v" || args[0] == "--version")){
+
+    if(contains_any(args, {"-v", "--version"})){
         cout << "This is " << "\033[35;1mLDPL " << STANDARD << " version " << VERSION << "\033[0m" << endl << endl;
         cout << "Copyright 2018-2019, Martín del Río" << endl << endl;
         cout << "Standard and documentation can be found on \033[36;1mldpl.lartu.net\033[0m." << endl;
@@ -21,7 +39,7 @@ int main(int argc, const char* argv[])
         cout << "Compiled on " << COMPILEDATE << endl;
         return 0;
     }
-    else if(args.size() == 1 && (args[0] == "-h" || args[0] == "--help")){
+    else if(contains_any(args, {"-h", "--help"})){
         cout << "Usage: ldpl [options] file [arguments]" << endl;
         cout << "Options:" << endl;
         cout << "  -h --help                Display this information" << endl;

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <fstream>
 #include <string>


### PR DESCRIPTION
Previously a command such as:
```
ldpl -h foo
```
or
```
ldpl -v foo
```
would ignore the help/version argument and attempt to run the file foo.

This commit changes this behavior such that any time -v, --version, -h,
or --help is supplied the version/help info will be displayed.

----

Example
```
# CURRENT MASTER
~/code/ldpl/src[master !?]$ ./ldpl-master -h
Usage: ldpl [options] file [arguments]
Options:
  -h --help                Display this information
  -r                       Display generated C++ code
  -i=<file>                Include file in current compilation
  -v --version             Display LDPL version information

~/code/ldpl/src[master !?]$ ./ldpl-master --help
Usage: ldpl [options] file [arguments]
Options:
  -h --help                Display this information
  -r                       Display generated C++ code
  -i=<file>                Include file in current compilation
  -v --version             Display LDPL version information

~/code/ldpl/src[master !?]$ ./ldpl-master -h foo
LDPL Error: The file 'foo' couldn't be opened.

~/code/ldpl/src[master !?]$ ./ldpl-master --help foo
LDPL Error: The file 'foo' couldn't be opened.
```
```
# MY CHANGES
~/code/ldpl/src[master !?]$ ./ldpl -h
Usage: ldpl [options] file [arguments]
Options:
  -h --help                Display this information
  -r                       Display generated C++ code
  -i=<file>                Include file in current compilation
  -v --version             Display LDPL version information

~/code/ldpl/src[master !?]$ ./ldpl --help
Usage: ldpl [options] file [arguments]
Options:
  -h --help                Display this information
  -r                       Display generated C++ code
  -i=<file>                Include file in current compilation
  -v --version             Display LDPL version information

~/code/ldpl/src[master !?]$ ./ldpl -h foo
Usage: ldpl [options] file [arguments]
Options:
  -h --help                Display this information
  -r                       Display generated C++ code
  -i=<file>                Include file in current compilation
  -v --version             Display LDPL version information

~/code/ldpl/src[master !?]$ ./ldpl --help foo
Usage: ldpl [options] file [arguments]
Options:
  -h --help                Display this information
  -r                       Display generated C++ code
  -i=<file>                Include file in current compilation
  -v --version             Display LDPL version information
```