### PR TITLE
Kill trailing 0s when converting from number->text

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -612,7 +612,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(" + tokens[1] + ", to_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(" + tokens[1] + ", to_ldpl_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $string AND $num-var IN $str-var", tokens, state))
@@ -620,7 +620,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(" + tokens[1] + ", to_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(" + tokens[1] + ", to_ldpl_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $string AND $str-var IN $str-var", tokens, state))
@@ -637,7 +637,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" + tokens[1] + "), " + tokens[3] + ", " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" + tokens[1] + "), " + tokens[3] + ", " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $number AND $number IN $str-var", tokens, state))
@@ -645,7 +645,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" + tokens[1] + "), to_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" + tokens[1] + "), to_ldpl_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $number AND $num-var IN $str-var", tokens, state))
@@ -653,7 +653,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" + tokens[1] + "), to_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" + tokens[1] + "), to_ldpl_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $number AND $str-var IN $str-var", tokens, state))
@@ -661,7 +661,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" + tokens[1] + "), " + get_c_variable(state, tokens[3]) + ", " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" + tokens[1] + "), " + get_c_variable(state, tokens[3]) + ", " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
 
@@ -678,7 +678,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(" +get_c_variable(state, tokens[1]) + ", to_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(" +get_c_variable(state, tokens[1]) + ", to_ldpl_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $str-var AND $num-var IN $str-var", tokens, state))
@@ -686,7 +686,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(" +get_c_variable(state, tokens[1]) + ", to_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(" +get_c_variable(state, tokens[1]) + ", to_ldpl_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $str-var AND $str-var IN $str-var", tokens, state))
@@ -703,7 +703,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" +get_c_variable(state, tokens[1]) + "), " + tokens[3] + ", " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" +get_c_variable(state, tokens[1]) + "), " + tokens[3] + ", " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $num-var AND $number IN $str-var", tokens, state))
@@ -711,7 +711,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" +get_c_variable(state, tokens[1]) + "), to_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" +get_c_variable(state, tokens[1]) + "), to_ldpl_string(" + tokens[3] + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $num-var AND $num-var IN $str-var", tokens, state))
@@ -719,7 +719,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" +get_c_variable(state, tokens[1]) + "), to_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" +get_c_variable(state, tokens[1]) + "), to_ldpl_string(" + get_c_variable(state, tokens[3]) + "), " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("JOIN $num-var AND $str-var IN $str-var", tokens, state))
@@ -727,7 +727,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(to_string(" +get_c_variable(state, tokens[1]) + "), " + get_c_variable(state, tokens[3]) + ", " + get_c_variable(state, tokens[5]) + ");");
+        state.add_code("join(to_ldpl_string(" +get_c_variable(state, tokens[1]) + "), " + get_c_variable(state, tokens[3]) + ", " + get_c_variable(state, tokens[5]) + ");");
         return;
     }
     if(line_like("GET CHARACTER AT $num-var FROM $str-var IN $str-var", tokens, state))
@@ -1560,7 +1560,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("STORE statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code(get_c_variable(state, tokens[3]) + " = to_string(" + tokens[1] +");");
+        state.add_code(get_c_variable(state, tokens[3]) + " = to_ldpl_string(" + tokens[1] +");");
         return;
     }
     if(line_like("STORE $num-var IN $str-var", tokens, state))
@@ -1568,7 +1568,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("STORE statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code(get_c_variable(state, tokens[3]) + " = to_string(" + get_c_variable(state, tokens[1]) +");");
+        state.add_code(get_c_variable(state, tokens[3]) + " = to_ldpl_string(" + get_c_variable(state, tokens[1]) +");");
         return;
     }
     if(line_like("STORE $string IN $num-var", tokens, state))
@@ -1633,13 +1633,13 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.add_code("joinvar = \"\";");
         for(unsigned int i = 3; i < tokens.size(); ++i){
             if(is_num_var(tokens[i], state)){
-                state.add_code("join(joinvar, to_string(" + get_c_variable(state, tokens[i]) + "), joinvar);");
+                state.add_code("join(joinvar, to_ldpl_string(" + get_c_variable(state, tokens[i]) + "), joinvar);");
             }
             else if(is_txt_var(tokens[i], state)){
                 state.add_code("join(joinvar, " + get_c_variable(state, tokens[i]) + ", joinvar);");
             }
             else if(is_number(tokens[i])){
-                state.add_code("join(joinvar, to_string(" + tokens[i] + "), joinvar);");
+                state.add_code("join(joinvar, to_ldpl_string(" + tokens[i] + "), joinvar);");
             }
             else{
                 state.add_code("join(joinvar, " + tokens[i] + ", joinvar);");

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -8,7 +8,7 @@
 #include <queue>
 #include <locale>
 #include "cpptrim.h"
-#include <fstream>
+#include <sstream>
 
 using namespace std;
 

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -166,6 +166,18 @@ string charat(const string & s, ldpl_number pos){
     return utf8_substr(s, pos, 1);
 }
 
+//Convert ldpl_number to LDPL string, killing trailing 0's
+//https://stackoverflow.com/questions/16605967/ & https://stackoverflow.com/questions/13686482/
+string to_ldpl_string(double x){
+    ostringstream out;
+    out.precision(10);
+    out << fixed << x;
+    string str = out.str();
+    str.erase(str.find_last_not_of('0') + 1, string::npos);
+    str.erase(str.find_last_not_of('.') + 1, string::npos);
+    return str;
+}
+
 #include <cstdio>
 #include <memory>
 #include <stdexcept>


### PR DESCRIPTION
Possible solution for #33 

Using this code:

```cobol
DATA:
t is text

PROCEDURE:
store 3.14 in t
display t crlf
store 100 in t
display t crlf
store 88.0123456789 in t
display t crlf
```

Output before this patch:

```
3.140000
100
88.012346
```

After this patch:

```
3.14
100
88.0123456789
```

I looked into overriding the default `std::to_string(double)` but it apparently can't be done, and also the precision can't be changed from 6, but maybe there's another cleaner way? 

