### PR TITLE
Add GOTO & LABEL

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -2264,11 +2264,30 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         return;
     }
 
+    if(line_like("LABEL $label", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("LABEL outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        state.add_code(fix_identifier(tokens[1])+":");
+        return;
+    }
+    if(line_like("GOTO $label", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("GOTO outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        state.add_code("goto "+fix_identifier(tokens[1])+";");
+        return;
+    }
+
     error("Malformed statement (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
 }
 
 string fix_identifier(string identifier, bool isVariable){
-    string new_id = isVariable ? "VAR_" : "SUBPR_";
+    return string(isVariable ? "VAR_" : "SUBPR_") + fix_identifier(identifier);
+}
+
+string fix_identifier(string identifier){
+    string new_id = "";
     for(unsigned int i = 0; i < identifier.size(); ++i){
         bool isValidChar = false;
         string validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
@@ -2347,6 +2366,10 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
         {
             if(!is_subprocedure(tokens[i], state)) return false;
         }
+        else if(model_tokens[i] == "$label") //$label is a GOTO label
+        {
+            return is_label(tokens[i]);
+        }
         else if(model_tokens[i] != tokens[i]) return false;
     }
     if(i < tokens.size()) return false;
@@ -2369,6 +2392,10 @@ bool is_natural(string number){
     for(char l : number)
         if(l == '.') return false;
     return true;
+}
+
+bool is_label(string & token){
+    return !isdigit(token[0]) && token[0] != ':' && token[0] != '"';
 }
 
 bool is_string(string & token){

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -62,6 +62,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
 bool line_like(string model_line, vector<string> & tokens, compiler_state & state); //Important to pass tokens by copy
 bool is_number(string number);
 bool is_natural(string number);
+bool is_label(string & token);
 bool is_string(string & token);
 bool is_vector_index(string & token);
 bool is_num_var(string & token, compiler_state & state);
@@ -74,3 +75,4 @@ void capitalize_tokens(vector<string> & tokens);
 void load_and_compile(string & filename, compiler_state & state);
 void replace_whitespace(string & code);
 string fix_identifier(string identifier, bool isVariable);
+string fix_identifier(string identifier);


### PR DESCRIPTION
My boss is really getting on my case about the big rewrite of our cryptocurrency platform in LDPL. He says we're not going to be able to move fast and break things if we don't have `GOTO` in the language.

I told him most people think `GOTO` is more harmful than helpful, and that it's known to be especially dangerous in complicated systems, but he said that he looked up this Dijkstra guy and he wasn't impressed with his Github profile.

So anyway, this patch adds two new keywords to LDPL: `GOTO` and `LABEL`. They are just piggybacking C++'s `goto`, really. Pretty barebones.

They have to both be used together in the same sub-procedure or in the main code body of an LDPL program. So you can't `goto` across functions or anything like that. 

Here's a little example script to test:

```cobol
procedure:
GOTO start

LABEL start
display "> starting..." crlf

GOTO ending

LABEL middle
display "> entering the middle section..." crlf

sub-procedure cool-code
    GOTO cool
    display "hmm... is this cool?" crlf
    LABEL cool
    LABEL SUBPR_COOL_CODE
    display "wow, yeah! cool code!" crlf
end sub-procedure

LABEL ending
CALL cool-code
display "> that's the end" crlf
```

The output, you can see `LABEL middle` and the start of the `cool-code` subprocedure are skipped:

```
> starting...
wow, yeah! cool code!
> that's the end