### PR TITLE
Convert invalid chars to numbers, not letters

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -2009,20 +2009,13 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
 //more restrictive name mangling algorithm: The only characters allowed are 
 //`A-Z`, `0-9`, and `_`. All other characters are converted to `_`. 
 string fix_external_identifier(string identifier, bool isVariable){
-    string new_id = "";
-    for(unsigned int i = 0; i < identifier.size(); ++i){
-        bool isValidChar = false;
-        string validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_";
-        for(unsigned int j = 0; j < validChars.size(); ++j){
-            if(validChars[j] == identifier[i]){
-                isValidChar = true;
-                break;
-            }
-        }
-        if(!isValidChar && identifier[i] != ':'){
-            new_id += "_";
-        }else{
+    const string validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890:";
+    string new_id;
+    for(unsigned int i = 0; i < identifier.size(); ++i){ 
+        if(validChars.find(identifier[i]) != string::npos){
             new_id += identifier[i];
+        }else{
+            new_id += "_";
         }
     }
     return new_id;
@@ -2042,25 +2035,16 @@ string fix_identifier(string identifier, bool isVariable){
 }
 
 string fix_identifier(string identifier){
-    string new_id = "";
-    for(unsigned int i = 0; i < identifier.size(); ++i){
-        bool isValidChar = false;
-        string validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-        for(unsigned int j = 0; j < validChars.size(); ++j){
-            if(validChars[j] == identifier[i]){
-                isValidChar = true;
-                break;
-            }
-        }
-        if(!isValidChar && identifier[i] != ':'){
-            char newchar = (((unsigned int) identifier[i]) % 25) + 65;
-            new_id += "r_";
-            new_id += newchar;
+    const string validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890:";
+    ostringstream new_id;
+    for(unsigned int i = 0; i < identifier.size(); ++i){ 
+        if(validChars.find(identifier[i]) != string::npos){
+            new_id << identifier[i];
         }else{
-            new_id += identifier[i];
+            new_id << "c" << (unsigned int)identifier[i] << "_";
         }
     }
-    return new_id;
+    return new_id.str();
 }
 
 //Check if the tokens of a line passed are like the ones of a model line


### PR DESCRIPTION
The way `fix_identifier` encodes invalid characters is causing some collisions, I think because it's only using the alphabet. 

For example, `-` and `_` both become `r_U`.

This patch changes it so the raw character number is used instead. The mangled names are nastier, but there won't be collisions.

The reason I didn't just "fix" this in master is I'm wondering if you had any other ideas for how to solve for the collisions? 

**Currently:**
```
one-two => VAR_ONEr_UTWO
one_two => VAR_ONEr_UTWO
one😎two => VAR_ONEr_Fr_Yr_Rr_HTWO
```

**With this patch:**

```
one-two => VAR_ONEc45_TWO
one_two => VAR_ONEc95_TWO
one😎two => VAR_ONEc4294967280_c4294967199_c4294967192_c4294967182_TWO
```

Here's a working example:

```
$ cat bug.lsc
DATA:
one-two is text
one_two is text

PROCEDURE:
store "okay" in one-two 
store "not okay" in one_two 

display "- " one-two crlf
display "_ " one-two crlf⏎
```
```
$ ldpl bug.lsc 
LDPL: Compiling...
ldpl-temp.cpp:232:8: error: redefinition of 'VAR_ONEr_UTWO'
string VAR_ONEr_UTWO = "";
       ^
ldpl-temp.cpp:231:8: note: previous definition is here
string VAR_ONEr_UTWO = "";
       ^
1 error generated.
LDPL Error: compilation failed.
```

Then, with this patch:

```
$ ldpl bug.lsc
LDPL: Compiling...
* File(s) compiled successfully.
* Saved as bug-bin
$  ./bug-bin
- okay
_ okay
