### PR TITLE
STORE QUOTE syntax for multi-line, literal strings

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -201,7 +201,7 @@ void compile(vector<string> & lines, compiler_state & state)
 
         if(state.open_quote){
             //Check for END QUOTE first
-            if(line.size() >= 9){ 
+            if(line.size() >= 9 && (line[0] == 'E' || line[0] == 'e')){
                 string upper = "";
                 for(char c : line) upper += toupper(c);
                 trim(upper);

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -209,7 +209,8 @@ void compile(vector<string> & lines, compiler_state & state)
                     state.open_quote = false;
                     //Kill final newline. Programs can add crlf if needed.
                     string & prev = state.output_code.back();
-                    if(prev.rfind("\\n") != string::npos) prev.erase(prev.size()-4, 3);
+                    size_t pos = prev.rfind("\\n");
+                    if(pos != string::npos) prev.erase(pos, 2);
                     prev += ";"; 
                     continue;
                 }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -217,7 +217,7 @@ void compile(vector<string> & lines, compiler_state & state)
             }
 
             //No END QUOTE, emit the line as C++
-            state.add_code("\"" + escape_c_string(line) + "\\n\"");
+            state.add_code("\"" + escape_c_quotes(line) + "\\n\"");
             continue;
         }
 
@@ -2337,17 +2337,15 @@ string get_c_variable(compiler_state & state, string & variable)
     return newvar;
 }
 
-//Escapes \ char in string so it can be emitted as c++
-string & escape_c_string(string & str)
+//Escapes " char in string so it can be emitted as c++
+string & escape_c_quotes(string & str)
 {
     for(unsigned int i = 0; i < str.size(); ++i){
         if(str[i] == '"'){
             str.erase(i, 1);
             str.insert(i, "\\\"");
             ++i;
-        }else if(str[i] == '\\'){
-            str.insert(++i, "\\");
-        }   
+        }
     }
     return str;
 }

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -37,6 +37,7 @@ struct compiler_state{
         else
             this->subroutine_code.push_back(code);
     }
+    bool open_quote = false;
     int open_ifs = 0;
     int while_number = 0;
     stack<int> while_stack;
@@ -66,6 +67,7 @@ bool is_external(string & token, compiler_state & state);
 bool variable_exists(string & token, compiler_state & state);
 bool is_subprocedure(string & token, compiler_state & state);
 string get_c_variable(compiler_state & state, string & variable);
+string & escape_c_string(string & str);
 void capitalize_tokens(vector<string> & tokens);
 void load_and_compile(string & filename, compiler_state & state);
 void replace_whitespace(string & code);

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -67,7 +67,7 @@ bool is_external(string & token, compiler_state & state);
 bool variable_exists(string & token, compiler_state & state);
 bool is_subprocedure(string & token, compiler_state & state);
 string get_c_variable(compiler_state & state, string & variable);
-string & escape_c_string(string & str);
+string & escape_c_quotes(string & str);
 void capitalize_tokens(vector<string> & tokens);
 void load_and_compile(string & filename, compiler_state & state);
 void replace_whitespace(string & code);


### PR DESCRIPTION
This is a possible implementation for #12. Maybe people want to make HTML templates and stuff, well, now they can pretty easily using `STORE QUOTE IN $str-var` and `END QUOTE` syntax:

```
DATA:
content is text

PROCEDURE:
STORE QUOTE IN content
No strings attached! "This is a quote!" I said.
   All the whitespace and whatnot comes, too.

\t\t Nothing is escaped. This \t is just \ and t. 

Everything but the final newline. You've gotta add that, if you want it. -> 
END QUOTE
display "Here's the quote: " crlf content crlf 
```

Output:
```
Here's the quote: 
No strings attached! "This is a quote!" I said.
   All the whitespace and whatnot comes, too.

\t\t Nothing is escaped. This \t is just \ and t.

Everything but the final newline. You've gotta add that, if you want it. ->
```

Notes:
- Nothing is escaped.
- There is no final newline, but programs can add it with `crlf` or somethin'.
- `END QUOTE` must be alone on its own line.

Any ideas for better syntax? Or did you envision it as just expanding `"` to support multi-line strings? I thought about that, but was thinking it would be annoying to escape every `"`, but maybe it's nice because there's no new syntax. 
