### PR TITLE
Fix ABS

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -716,7 +716,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("ABS statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("fabs("+get_c_variable(state, tokens[5])+");");
+        state.add_code(get_c_variable(state, tokens[1]) + " = fabs("+get_c_variable(state, tokens[1])+");");
         return;
     }
     if(line_like("JOIN $string AND $string IN $str-var", tokens, state))


### PR DESCRIPTION
ABS isn't working in master, it gets the wrong token and doesn't assign the result to the variable. This PR fix it.

Example code:

```
DATA:

n is number

PROCEDURE:

store -1 in n
abs n
display n crlf
```