### PR TITLE
No static builds on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Example code can be found on [the LDPL website](https://www.ldpl-lang.org).
  * The `-f` flag can be used to pass extra options to the compiler when building extensions. For example, `-f=-lSDL` could be used to link against SDL.
  * By using `-r` you can just compile the project and print the C++ representation for that code.
  * You can set the output file for the compiled binary with the `-o` flag. For example, if you want to name your program "dog", you could compile it with `ldpl -o=dog main.ldpl`.
- * On Linux and Windows platforms, LDPL builds static binaries by default. If you want to build non-static ones use the `-ns` flag. To build on Android Termux you must use this flag.
  * `-v` and `--version` print out version info and release details.
  * `-h` and `--help` print this list of options.
 

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -45,9 +45,6 @@ int main(int argc, const char* argv[])
         cout << "  -i=<file>                Include file in current compilation" << endl;
         cout << "  -f=<flag>                Pass a flag to the C++ compiler" << endl;
         cout << "  -v --version             Display LDPL version information" << endl;
-		#ifdef  STATIC_BUILDS
-		cout << "  -ns             			Disables static binary building" << endl;
-		#endif
         return 0;
     }
 
@@ -55,10 +52,6 @@ int main(int argc, const char* argv[])
     vector<string> files_to_compile;
     vector<string> extensions;
     add_ldpllib(state);
-
-#ifdef STATIC_BUILDS
-	bool no_static = false;
-#endif
 
     string output_filename = "";
     string final_filename = "";
@@ -73,11 +66,6 @@ int main(int argc, const char* argv[])
             else if(arg == "-r"){
                 show_ir = true;
             }
-			#ifdef STATIC_BUILDS
-			else if(arg == "-ns"){
-                no_static = true;
-            }
-			#endif
             else if(arg.substr(0, 3) == "-o="){
                 final_filename = arg.substr(3);
             }
@@ -152,7 +140,7 @@ int main(int argc, const char* argv[])
     cout << "LDPL: Compiling..." << endl;
     string compile_line = "c++ ldpl-temp.cpp -std=gnu++11 -o " + final_filename;
 #ifdef STATIC_BUILDS
-    if(!no_static) compile_line+=" -static-libgcc -static-libstdc++ ";
+    compile_line+=" -static-libgcc -static-libstdc++ ";
 #endif
     if(!extensions.empty()){
         for(string & extension : extensions) compile_line += " "+extension;

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -12,7 +12,7 @@
 
 using namespace std;
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__ANDROID__)
 #define STATIC_BUILDS 1
 #endif
 


### PR DESCRIPTION
@lartu Did you want to revert the `-ns` flag altogether since it's not required anymore? Wasn't sure but I reverted it in this PR.