### PR TITLE
Check for ':' in names

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -2077,7 +2077,7 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
     {
         if(model_tokens[i] == "$name") //$name is any word that is not a string or a number
         {
-            for(char letter : model_tokens[i]) if(letter == ':') return false;
+            for(char letter : tokens[i]) if(letter == ':') return false;
             if(is_string(tokens[i])) return false;
             if(is_number(tokens[i])) return false;
         }


### PR DESCRIPTION
The check was being done on "$name" instead of the token.

Example code:
```ldpl
DATA:

a:a is number
```