### PR TITLE
Experiment: Internal sub procedures

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -916,12 +916,16 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 2)
             error("INTERNAL SUB-PROCEDURE declaration outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        if(!is_subprocedure(tokens[2], state))
+            state.subprocedures.push_back(tokens[2]);
+        else
+            error("Duplicate declaration for subprocedure " + tokens[2] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         if(state.open_subprocedure != "")
             error("Subprocedure declaration inside subprocedure (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         else
             state.open_subprocedure = tokens[2];
         //C Code
-        state.add_code("void "+fix_external_identifier(tokens[2], false)+"(){");
+        state.add_code("void "+fix_identifier(tokens[2], false)+"(){");
         state.open_internal = true;
         return;
     }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -237,7 +237,7 @@ void compile(vector<string> & lines, compiler_state & state)
             if(state.open_quote)
                 state.add_code("\"" + escape_c_quotes(line) + "\\n\"");
             else if(state.open_internal)
-                state.add_code(line);
+                state.add_code(replace_internal_vars(line));
             continue;
         }
 
@@ -2393,6 +2393,25 @@ string & escape_c_quotes(string & str)
             str.erase(i, 1);
             str.insert(i, "\\\"");
             ++i;
+        }
+    }
+    return str;
+}
+
+//swaps {$name} with VAR_NAME in user-defined "internal" C++ code
+string & replace_internal_vars(string & str)
+{ 
+    string var = "";
+    for(unsigned int i = 0; i < str.size(); ++i){
+        if(str[i] == '{' && i < str.size() && str[i+1] == '$'){
+            var = "";
+            for(unsigned int j = i+2; j < str.size(); ++j){
+                if(str[j] == '}') break;
+                if(str[j] == ' ') continue;
+                var += str[j];
+            }
+            for(size_t z=0;z<var.size();++z) var[z] = toupper(var[z]);
+            str.replace(i, var.size()+3, fix_identifier(var, true));
         }
     }
     return str;

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -2402,20 +2402,27 @@ string & escape_c_quotes(string & str)
     return str;
 }
 
-//swaps {$name} with VAR_NAME in user-defined "internal" C++ code
+//Swaps {$name} with VAR_NAME and {$name}() with SUBPR_NAME() 
+//in user-defined "internal" C++ code.)
 string & replace_internal_vars(string & str)
 { 
     string var = "";
+    bool is_var = true;
     for(unsigned int i = 0; i < str.size(); ++i){
         if(str[i] == '{' && i < str.size() && str[i+1] == '$'){
+            is_var = true;
             var = "";
             for(unsigned int j = i+2; j < str.size(); ++j){
-                if(str[j] == '}') break;
+                if(str[j] == '}'){
+                    if(j+2 < str.size() && str[j+1] == '(' && str[j+2] == ')')
+                        is_var = false;
+                    break;
+                } 
                 if(str[j] == ' ') continue;
                 var += str[j];
             }
             for(size_t z=0;z<var.size();++z) var[z] = toupper(var[z]);
-            str.replace(i, var.size()+3, fix_identifier(var, true));
+            str.replace(i, var.size()+3, fix_identifier(var, is_var));
         }
     }
     return str;

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -41,6 +41,7 @@ struct compiler_state{
         else
             this->subroutine_code.push_back(code);
     }
+    bool open_internal = false;
     bool open_quote = false;
     int open_ifs = 0;
     int while_number = 0;

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -73,6 +73,7 @@ bool variable_exists(string & token, compiler_state & state);
 bool is_subprocedure(string & token, compiler_state & state);
 string get_c_variable(compiler_state & state, string & variable);
 string & escape_c_quotes(string & str);
+string & replace_internal_vars(string & str);
 void capitalize_tokens(vector<string> & tokens);
 void load_and_compile(string & filename, compiler_state & state);
 void replace_whitespace(string & code);


### PR DESCRIPTION
I have been thinking about this for a while and am not sure if there's any point, but seeing 25ed0ab539ab29fddf3bff425223ac3ba08abf0a made me think of it again. 

This branch allows you to define LDPL sub-procedures in C++ from within LDPL. It's similar to `STORE QUOTE` where it just dumps everything you give it into the compiled code, except it looks for `{$varname}` or `{$subname}()` and replaces them with LDPL variables for convenience.

I'm not sure it's worth making the compiler more complicated but I needed to see this working to satisfy my curiosity. :^ )  If this isn't a fit we don't have to add it. It's probably easier to just write a `.cpp` file and include it directly with `-i=`.

Here's what it looks like:

```
DATA:
x is number
y is number
sum is number

PROCEDURE:
internal sub-procedure fast-add 
    {$sum} = {$x} + {$y};
end sub-procedure

display "X value: "
accept x 

display "Y value: "
accept y

call sub-procedure fast-add

display "Sum is " sum crlf
```

Or like this:

```
DATA:
name is text

PROCEDURE:
sub-procedure prompt
    display "Enter your name: "
    accept name
end sub-procedure

internal sub-procedure greet
    if({$name}.empty()){
        {$prompt}();
    }
    cout << "Hi there, " << {$name} << "!!" << endl;
end sub-procedure

call sub-procedure greet
