### PR TITLE
Capitalize all vector names in subindexes

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -325,7 +325,7 @@ void capitalize_tokens(vector<string> & tokens)
             if(is_vector_index(token))
             {
                 for(char & l : token){
-                    if (l == ':') break;
+                    if (l == '"' && *(&l - 1) == ':') break;
                     l = toupper(l);
                 }
             }


### PR DESCRIPTION
The names of vector used in subindexes were not capitalized if the last index was a text literal.

Example code:
```ldpl
DATA:

v is number vector

PROCEDURE:

display v:v:"hi" crlf 
```