### PR TITLE
Improve block closing errors

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -245,7 +245,7 @@ void compile(vector<string> & lines, compiler_state & state)
         error("there may be open IF blocks in your code.");
         exit(1);
     }
-    if(state.while_stack.size() > 0){
+    if(state.open_whiles > 0){
         error("there may be open WHILE blocks in your code.");
         exit(1);
     }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -250,6 +250,7 @@ void compile(vector<string> & lines, compiler_state & state)
         exit(1);
     }
     if(state.open_quote) error("your QUOTE block was not terminated.");
+    if(state.open_subprocedure != "") error("your SUB-PROCEDURE was not terminated.");
 }
 
 //Tokenizes a line

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -466,13 +466,13 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     
     //increment open IF count if this is an if statement
     if(tokens[0] == "IF")
-        ++state.open_ifs;
+        state.open_if();
 
     //handle ELSE and ELSE IF 
     if(tokens[0] == "ELSE"){
         if(state.section_state != 2)
             error("ELSE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(state.open_ifs == 0)
+        if(!state.closing_if())
             error("ELSE without IF (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
 
         if(tokens.size() == 1){ // ELSE
@@ -1205,10 +1205,10 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 2)
             error("END IF outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(state.open_ifs == 0)
+        if(!state.closing_if())
             error("END IF without IF (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        --state.open_ifs;
+        state.close_if();
         state.add_code("}");
         return;
     }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -250,7 +250,7 @@ void compile(vector<string> & lines, compiler_state & state)
         exit(1);
     }
     if(state.open_quote) error("your QUOTE block was not terminated.");
-    if(state.open_subprocedures) error("your SUB-PROCEDURE was not terminated.");
+    if(state.in_subprocedure) error("your SUB-PROCEDURE was not terminated.");
 }
 
 //Tokenizes a line
@@ -897,7 +897,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
             state.subprocedures.push_back(tokens[1]);
         else
             error("Duplicate declaration for subprocedure " + tokens[1] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(state.open_subprocedures)
+        if(state.in_subprocedure)
             error("Subprocedure declaration inside subprocedure (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         else
             state.open_subprocedure();
@@ -909,7 +909,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 2)
             error("EXTERNAL SUB-PROCEDURE declaration outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(state.open_subprocedures)
+        if(state.in_subprocedure)
             error("Subprocedure declaration inside subprocedure (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         else
             state.open_subprocedure();
@@ -921,7 +921,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 2)
             error("RETURN outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(!state.open_subprocedures)
+        if(!state.in_subprocedure)
             error("RETURN found outside subprocedure (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
         state.add_code("return;");

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -241,16 +241,10 @@ void compile(vector<string> & lines, compiler_state & state)
         if(tokens.size() == 0) continue;
         compile_line(tokens, line_num, state);
     }
-    if(state.open_ifs > 0){
-        error("there may be open IF blocks in your code.");
-        exit(1);
-    }
-    if(state.open_whiles > 0){
-        error("there may be open WHILE blocks in your code.");
-        exit(1);
-    }
     if(state.open_quote) error("your QUOTE block was not terminated.");
-    if(state.in_subprocedure) error("your SUB-PROCEDURE was not terminated.");
+    if(state.closing_subprocedure()) error("your SUB-PROCEDURE block was not terminated.");
+    if(state.closing_if()) error("your IF block was not terminated.");
+    if(state.closing_while()) error("your WHILE block was not terminated.");
 }
 
 //Tokenizes a line

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1218,7 +1218,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (num_equal(" + tokens[1] + ", " + tokens[5] + ")){");
         return;
     }
@@ -1227,7 +1227,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (num_equal(" + tokens[1] + ", " + get_c_variable(state, tokens[5]) + ")){");
         return;
     }
@@ -1236,7 +1236,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (num_equal(" + get_c_variable(state, tokens[1]) + ", " + tokens[5] + ")){");
         return;
     }
@@ -1245,7 +1245,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (num_equal(" + get_c_variable(state, tokens[1]) + ", " + get_c_variable(state, tokens[5]) + ")){");
         return;
     }
@@ -1255,7 +1255,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (!num_equal(" + tokens[1] + ", " + tokens[6] + ")){");
         return;
     }
@@ -1264,7 +1264,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (!num_equal(" + tokens[1] + ", " + get_c_variable(state, tokens[6]) + ")){");
         return;
     }
@@ -1273,7 +1273,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (!num_equal(" + get_c_variable(state, tokens[1]) + ", " + tokens[6] + ")){");
         return;
     }
@@ -1282,7 +1282,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (!num_equal(" + get_c_variable(state, tokens[1]) + ", " + get_c_variable(state, tokens[6]) + ")){");
         return;
     }
@@ -1292,7 +1292,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " > " + tokens[5] + "){");
         return;
     }
@@ -1301,7 +1301,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " > " + get_c_variable(state, tokens[5]) + "){");
         return;
     }
@@ -1310,7 +1310,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " > " + tokens[5] + "){");
         return;
     }
@@ -1319,7 +1319,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " > " + get_c_variable(state, tokens[5]) + "){");
         return;
     }
@@ -1329,7 +1329,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " < " + tokens[5] + "){");
         return;
     }
@@ -1338,7 +1338,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " < " + get_c_variable(state, tokens[5]) + "){");
         return;
     }
@@ -1347,7 +1347,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " < " + tokens[5] + "){");
         return;
     }
@@ -1356,7 +1356,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " < " + get_c_variable(state, tokens[5]) + "){");
         return;
     }
@@ -1366,7 +1366,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " > " + tokens[8] + " || num_equal(" + tokens[1] + ", " + tokens[8] + ")){");
         return;
     }
@@ -1375,7 +1375,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " > " + get_c_variable(state, tokens[8]) + " || num_equal(" + tokens[1] + ", " + get_c_variable(state, tokens[8]) + ")){");
         return;
     }
@@ -1384,7 +1384,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " > " + tokens[8] + " || num_equal(" + get_c_variable(state, tokens[1]) + ", " + tokens[8] + ")){");
         return;
     }
@@ -1393,7 +1393,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " > " + get_c_variable(state, tokens[8]) + " || num_equal(" + get_c_variable(state, tokens[1]) + ", " + get_c_variable(state, tokens[8]) + ")){");
         return;
     }
@@ -1403,7 +1403,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " < " + tokens[8] + " || num_equal(" + tokens[1] + ", " + tokens[8] + ")){");
         return;
     }
@@ -1412,7 +1412,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " < " + get_c_variable(state, tokens[8]) + " || num_equal(" + tokens[1] + ", " + get_c_variable(state, tokens[8]) + ")){");
         return;
     }
@@ -1421,7 +1421,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " < " + tokens[8] + " || num_equal(" + get_c_variable(state, tokens[1]) + ", " + tokens[8] + ")){");
         return;
     }
@@ -1430,7 +1430,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " < " + get_c_variable(state, tokens[8]) + " || num_equal(" + get_c_variable(state, tokens[1]) + ", " + get_c_variable(state, tokens[8]) + ")){");
         return;
     }
@@ -1440,14 +1440,14 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " == " + tokens[5] + "){");
         return;
     }
     if(line_like("WHILE $string IS EQUAL TO $str-var DO", tokens, state))
     {
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " == " + get_c_variable(state, tokens[5]) + "){");
         return;
     }
@@ -1456,7 +1456,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " == " + tokens[5] + "){");
         return;
     }
@@ -1465,7 +1465,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " == " + get_c_variable(state, tokens[5]) + "){");
         return;
     }
@@ -1475,7 +1475,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " != " + tokens[6] + "){");
         return;
     }
@@ -1484,7 +1484,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + tokens[1] + " != " + get_c_variable(state, tokens[6]) + "){");
         return;
     }
@@ -1493,7 +1493,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " != " + tokens[6] + "){");
         return;
     }
@@ -1502,7 +1502,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("WHILE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_while();
+        state.open_while();
         state.add_code("while (" + get_c_variable(state, tokens[1]) + " != " + get_c_variable(state, tokens[6]) + "){");
         return;
     }
@@ -1511,10 +1511,10 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 2)
             error("REPEAT outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(state.while_stack.size() == 0)
+        if(!state.closing_while())
             error("REPEAT without WHILE (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.while_stack.pop();
+        state.close_while();
         state.add_code("}");
         return;
     }
@@ -1523,7 +1523,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 2)
             error("BREAK outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(state.while_stack.size() == 0)
+        if(state.open_whiles == 0)
             error("BREAK without WHILE (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
         state.add_code("break;");
@@ -1534,7 +1534,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 2)
             error("CONTINUE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(state.while_stack.size() == 0)
+        if(state.open_whiles == 0)
             error("CONTINUE without WHILE (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
         state.add_code("continue;");

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -54,7 +54,7 @@ struct compiler_state{
         block_stack.pop();
     }
     bool closing_subprocedure(){
-        return block_stack.top() == 0;
+        return !block_stack.empty() && block_stack.top() == 0;
     }
     void open_if(){
         ++open_ifs;
@@ -65,7 +65,7 @@ struct compiler_state{
         block_stack.pop();
     }
     bool closing_if(){
-        return block_stack.top() == 1;
+        return !block_stack.empty() && block_stack.top() == 1;
     }
     void open_while(){
         ++open_whiles;
@@ -76,7 +76,7 @@ struct compiler_state{
         block_stack.pop();
     }
     bool closing_while(){
-        return block_stack.top() == 2;
+        return !block_stack.empty() && block_stack.top() == 2;
     }
     stack<string> working_dir;
 };

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -20,7 +20,6 @@ using namespace std;
 struct compiler_state{
     unsigned int section_state = 0; //0 no section, 1 data, 2 procedure
     unsigned int current_line = 0;
-    bool in_subroutine = false;
     string current_file = "";
     //Code to output (plain C code)
     vector<string> variable_code;
@@ -35,22 +34,22 @@ struct compiler_state{
         this->variable_code.push_back(code);
     }
     void add_code(string code){
-        if(!open_subprocedures)
+        if(!in_subprocedure)
             this->output_code.push_back(code);
         else
             this->subroutine_code.push_back(code);
     }
     bool open_quote = false;
-    bool open_subprocedures;
+    bool in_subprocedure = false;
     int open_ifs = 0;
     int open_whiles = 0;
     stack<int> block_stack; //0 sub-procedure, 1 if, 2 while
     void open_subprocedure(){
-        open_subprocedures = true;
+        in_subprocedure = true;
         block_stack.push(0);
     }
     void close_subprocedure(){
-        open_subprocedures = false;
+        in_subprocedure = false;
         block_stack.pop();
     }
     bool closing_subprocedure(){

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -41,7 +41,6 @@ struct compiler_state{
     }
     bool open_quote = false;
     bool in_subprocedure = false;
-    int open_ifs = 0;
     int open_whiles = 0;
     stack<int> block_stack; //0 sub-procedure, 1 if, 2 while
     void open_subprocedure(){
@@ -56,11 +55,9 @@ struct compiler_state{
         return !block_stack.empty() && block_stack.top() == 0;
     }
     void open_if(){
-        ++open_ifs;
         block_stack.push(1);
     }
     void close_if(){
-        --open_ifs;
         block_stack.pop();
     }
     bool closing_if(){

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -43,12 +43,18 @@ struct compiler_state{
     }
     bool open_quote = false;
     int open_ifs = 0;
-    int while_number = 0;
-    stack<int> while_stack;
-    int add_while(){
-        ++while_number;
-        while_stack.push(while_number);
-        return while_number;
+    int open_whiles = 0;
+    stack<int> block_stack; //0 sub-procedure, 1 if, 2 while
+    void open_while(){
+        ++open_whiles;
+        block_stack.push(2);
+    }
+    void close_while(){
+        --open_whiles;
+        block_stack.pop();
+    }
+    bool closing_while(){
+        return block_stack.top() == 2;
     }
     stack<string> working_dir;
 };

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -45,6 +45,17 @@ struct compiler_state{
     int open_ifs = 0;
     int open_whiles = 0;
     stack<int> block_stack; //0 sub-procedure, 1 if, 2 while
+    void open_if(){
+        ++open_ifs;
+        block_stack.push(1);
+    }
+    void close_if(){
+        --open_ifs;
+        block_stack.pop();
+    }
+    bool closing_if(){
+        return block_stack.top() == 1;
+    }
     void open_while(){
         ++open_whiles;
         block_stack.push(2);

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -31,20 +31,31 @@ struct compiler_state{
     map<string, bool> externals; //variables defined in c++ extensions
     //1 number, 2 text, 3 number vector, 4 text vector
     vector<string> subprocedures;
-    string open_subprocedure = "";
     void add_var_code(string code){
         this->variable_code.push_back(code);
     }
     void add_code(string code){
-        if(open_subprocedure == "")
+        if(!open_subprocedures)
             this->output_code.push_back(code);
         else
             this->subroutine_code.push_back(code);
     }
     bool open_quote = false;
+    bool open_subprocedures;
     int open_ifs = 0;
     int open_whiles = 0;
     stack<int> block_stack; //0 sub-procedure, 1 if, 2 while
+    void open_subprocedure(){
+        open_subprocedures = true;
+        block_stack.push(0);
+    }
+    void close_subprocedure(){
+        open_subprocedures = false;
+        block_stack.pop();
+    }
+    bool closing_subprocedure(){
+        return block_stack.top() == 0;
+    }
     void open_if(){
         ++open_ifs;
         block_stack.push(1);


### PR DESCRIPTION
Now we check proper closing of nested blocks, throwing error if we find something like this:
```ldpl
PROCEDURE:

sub-procedure mySubprocedure
    if "" is equal to "" then
        while "" is not equal to "" do
end sub-procedure
    end if
        repeat
```

We also check that there isn't an unterminated procedure block, like this:
```ldpl
PROCEDURE:

sub-procedure mySubprocedure
```