### PR TITLE
Check whole string in is_number

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1107,13 +1107,10 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
 }
 
 bool is_number(string number){
-  try {
-    stod(number);
-  }
-  catch (const std::invalid_argument& ia) {
-      return false;
-  }
-  return true;
+    istringstream iss(number);
+    float f;
+    iss >> f;
+    return iss.eof() && !iss.fail(); 
 }
 
 bool is_natural(string number){


### PR DESCRIPTION
The stod test passed on strings that starts like a number (`"1a"`, `"0.3e23udonki"`), producing errors on C++ compiling. Now the whole string must be a valid numeric representation.

Example:
```ldpl
PROCEDURE:
display 0.3e23udonki
```