### PR TITLE
Add basic support for math expressions with IN-SOLVE

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -851,6 +851,21 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.add_code(get_c_variable(state, tokens[1]) + " = joinvar;");
         return;
     }
+    if(line_like("IN $num-var SOLVE $math", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("IN-SOLVE statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+
+        string code = "";
+        for(unsigned int i = 3; i < tokens.size(); ++i){
+            if(is_num_var(tokens[i], state))
+                code += " " + fix_identifier(tokens[i], true);
+            else
+                code += " " + tokens[i];
+        }
+        state.add_code(get_c_variable(state, tokens[1]) + " =" + code + ";");
+        return;
+    }
     //REPLACE x FROM y WITH z IN w
     if(line_like("REPLACE $str-var FROM $str-expr WITH $str-expr IN $str-var", tokens, state))
     {
@@ -1070,6 +1085,36 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
         {
             return is_label(tokens[j]);
         }
+        else if(model_tokens[i] == "$math") //$math is a math expression
+        {
+            vector<string> maths; //further tokenize math expressions
+            string math_token = "";
+            for(; j < tokens.size(); ++j){
+                for(unsigned int z = 0; z < tokens[j].size(); ++z){
+                    if(tokens[j][z] == '(' || tokens[j][z] == ')'){
+                        if(!math_token.empty()) maths.push_back(math_token);
+                        math_token = tokens[j][z];
+                        maths.push_back(math_token);
+                        math_token = "";
+                    }else{
+                        math_token += tokens[j][z];
+                    }
+                }
+                if(!math_token.empty()) maths.push_back(math_token);
+                math_token = "";
+            }
+            //replace LDPL line tokens with new math tokens
+            tokens.erase(tokens.begin()+i, tokens.end());
+            tokens.insert(tokens.end(), maths.begin(), maths.end());
+
+            //validate the new tokens
+            for(unsigned int z = i; z < tokens.size(); ++z){
+                if(tokens[z] != "(" && tokens[z] != ")" && !is_number(tokens[z]) 
+                && !is_num_var(tokens[z], state) && !is_math_symbol(tokens[z])) 
+                    return false;
+            }
+            return true;
+        }
         else if(model_tokens[i] == "$condition") //$condition is a IF/WHILE condition
         {
             // Note: We assume that there is only one token after $condition,
@@ -1125,6 +1170,11 @@ bool is_label(string & token){
     //return !isdigit(token[0]) && token[0] != ':' && token[0] != '"';
     for(char letter : token) if(letter == '\"') return false;
     return true;
+}
+
+bool is_math_symbol(string & token){
+    string syms = "+-*/";
+    return token.size() == 1 && syms.find(token[0]) != string::npos;
 }
 
 bool is_string(string & token){

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1109,8 +1109,7 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
 
             //validate the new tokens
             for(unsigned int z = i; z < tokens.size(); ++z){
-                if(tokens[z] != "(" && tokens[z] != ")" && !is_number(tokens[z]) 
-                && !is_num_var(tokens[z], state) && !is_math_symbol(tokens[z])) 
+                if(!is_number(tokens[z]) && !is_num_var(tokens[z], state) && !is_math_symbol(tokens[z]))
                     return false;
             }
             return true;
@@ -1173,7 +1172,7 @@ bool is_label(string & token){
 }
 
 bool is_math_symbol(string & token){
-    string syms = "+-*/";
+    string syms = "+-*/()";
     return token.size() == 1 && syms.find(token[0]) != string::npos;
 }
 

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -86,6 +86,7 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
 bool is_number(string number);
 bool is_natural(string number);
 bool is_label(string & token);
+bool is_math_symbol(string & symbol);
 bool is_string(string & token);
 bool is_vector_index(string & token);
 bool is_num_var(string & token, compiler_state & state);


### PR DESCRIPTION
This is basic support for expressions as per #41. 

The syntax is: `IN num-var SOLVE math-expression`

Right now it only supports the big four `+-*/` operations. It could be expanded to support `abs` and `ceil` probably, if that's the direction we want to go, but this was the simplest since it's just re-using C++'s operators. 

**Example**

```python
DATA:
square/num is number
square/res is number

x is number
y is number 
z is number

PROCEDURE:
sub-procedure square
  in square/res solve square/num * square/num
end sub-procedure

store 10 in square/num
call square 
display "the square of " square/num " is " square/res crlf

store 1 in x
store 2 in y
in z solve x + y
display x " + " y " = " z crlf

in z solve x * (20 / (1 + y + y)) - 3.14
display "z: " z crlf 
```

**Output**
```
$ ./math-bin                                     
the square of 10 is 100
1 + 2 = 3
z: 0.86
```