### PR TITLE
Advise Windows user to change git core.autoclrf config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Then `make` and `make install` LDPL in the `src` folder. This will install LDPL 
 LDPL requires only C++11 to compile.
 
 **Note for Windows users:** compilation under Windows has been tested with [MinGW](http://www.mingw.org/wiki/Getting_Started) as installed on that guide. MinGW-w64 seems to have some problems compiling LDPL.
+Also, it is advised to configure git autoclrf to use Unix-style end-of-line: `git config core.autocrlf input`. LDPL relies on an AWK script which will not work properly with DOS-style newlines (CLRF).
 
 Once you have LDPL installed, check the LDPL reference to learn how to use the language. Information on how to compile LDPL scripts and a list of LDPL compatible editors is provided below.
 


### PR DESCRIPTION
Earlier, I was trying to build LDPL on Windows (for æsthetic reasons, let's say) and stumble on a lenghty compilation error. `ldpl_included_lib.cpp` was ill-formed.

I had no such issue on GNU/Linux, and I quickly found out that Awk does not work well with DOS EOL. For instance, where you would expect:
```cpp
void add_ldpllib(compiler_state & state){
    state.add_var_code("#include <sstream>");
    state.add_var_code("#include <math.h>");
```
this is what I had:
```cpp
void add_ldpllib(compiler_state & state){
    state.add_var_code("#include <sstream>
");
    state.add_var_code("#include <math.h>
");
```

I though it would be wise to mention in the README that windows user should change their git config to use Unix EOL. It's not like it's an issue with most available tools and editor nowadays.

I'll also check the documentation repo to mention this pitfall there as well.

