### PR TITLE
Make -i include order match what's passed

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -101,7 +101,7 @@ int main(int argc, const char* argv[])
             }
             else if(arg.substr(0, 3) == "-i="){
                 if(0 == arg.compare(arg.length()-5, 5, ".ldpl")||0 == arg.compare(arg.length()-4, 4, ".lsc")){
-                    files_to_compile.insert(files_to_compile.begin(), arg.substr(3));
+                    files_to_compile.push_back(arg.substr(3));
                 }else{
                     //pass everything but .ldpl and .lsc files to the c++ compiler
                     extensions.push_back(arg.substr(3)); // kill -i= prefix


### PR DESCRIPTION
Files passed to `-i=` on the command line are being compiled in the reverse order given, leading to (unexpected?) dependency issues.

For example:

```
$ cat a.ldpl 
DATA:
a is text

$ cat b.ldpl 
DATA:
b is text

PROCEDURE:
store "yay" in a

$ cat c.ldpl  
PROCEDURE:
display a crlf
display b crlf

$ ldpl -i=a.ldpl -i=b.ldpl c.ldpl 
LDPL Error: Malformed statement (b.ldpl:5)
```

This errors because `b.ldpl` is actually compiled first right now. With this patch, running the same code above preserves the compilation order:

```
$ ldpl -i=a.ldpl -i=b.ldpl c.ldpl 
LDPL: Compiling...
* File(s) compiled successfully.
* Saved as c-bin
$ ./c-bin
yay
```

I know we're going to rework `-i` in the future but I thought this might be worth changing now. 
