### PR TITLE
Speed up text character lookup

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -806,7 +806,15 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("JOIN statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code("join(" + get_c_string(state, tokens[1]) + ", " + get_c_string(state, tokens[3]) + ", " + get_c_variable(state, tokens[5]) + ");");
+        string arg_a = get_c_string(state, tokens[1]);
+        string arg_b = get_c_string(state, tokens[3]);
+        string arg_c = get_c_variable(state, tokens[5]);
+        if(arg_a == arg_c)
+            state.add_code(arg_a + " += " + arg_b + ";");
+        else if(arg_b == arg_c)
+            state.add_code(arg_b + " += " + arg_a + ";");
+        else
+            state.add_code("join(" + arg_a + ", " + arg_b + ", " + arg_c + ");");
         return;
     }
     if(line_like("GET CHARACTER AT $num-expr FROM $str-expr IN $str-var", tokens, state))

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -811,8 +811,6 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         string arg_c = get_c_variable(state, tokens[5]);
         if(arg_a == arg_c)
             state.add_code(arg_a + " += " + arg_b + ";");
-        else if(arg_b == arg_c)
-            state.add_code(arg_b + " += " + arg_a + ";");
         else
             state.add_code("join(" + arg_a + ", " + arg_b + ", " + arg_c + ");");
         return;

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -176,9 +176,25 @@ ldpl_number get_char_num(const string & chr){
     return ord;
 }
 
-string charat(const string & s, ldpl_number pos){
-    unsigned int _pos = floor(pos);
-    return utf8_substr(s, pos, 1);
+unordered_map<size_t, ldpl_vector<string>> char_cache;
+string charat(const string & s, ldpl_number pos) {
+    unsigned int ipos = floor(pos);
+    size_t hash = std::hash<string>{}(s);
+    if(char_cache.find(hash)==char_cache.end()){
+        ldpl_vector<string> v;
+        ldpl_number x = 0;
+        for(size_t i = 0; i < s.length();){
+            int cplen = 1;
+            if((s[i] & 0xf8) == 0xf0) cplen = 4;
+            else if((s[i] & 0xf0) == 0xe0) cplen = 3;
+            else if((s[i] & 0xe0) == 0xc0) cplen = 2;
+            if((i + cplen) > s.length()) cplen = 1;
+            v[x++] = s.substr(i, cplen);
+            i += cplen;
+        }
+        char_cache[hash] = v;
+    }
+    return char_cache[hash][ipos];
 }
 
 //Convert ldpl_number to LDPL string, killing trailing 0's

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -180,6 +180,7 @@ ldpl_number get_char_num(const string & chr){
 unordered_map<size_t, unordered_map<size_t, pair<int, int>>> utf8cache;
 string charat(const string& s, ldpl_number pos) {
     unsigned int ipos = floor(pos);
+    if(ipos>=s.size()) return \"\";
     size_t id = (size_t)&s << s.size();
     if(utf8cache.find(id)==utf8cache.end()){
         unordered_map<size_t, pair<int, int>> m;

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -176,25 +176,27 @@ ldpl_number get_char_num(const string & chr){
     return ord;
 }
 
-unordered_map<size_t, ldpl_vector<string>> char_cache;
-string charat(const string & s, ldpl_number pos) {
+//cache utf8 point locations in map for faster lookups
+unordered_map<size_t, unordered_map<size_t, pair<int, int>>> utf8cache;
+string charat(const string& s, ldpl_number pos) {
     unsigned int ipos = floor(pos);
     size_t id = (size_t)&s;
-    if(char_cache.find(id)==char_cache.end()){
-        ldpl_vector<string> v;
-        ldpl_number x = 0;
+    if(utf8cache.find(id)==utf8cache.end()){
+        unordered_map<size_t, pair<int, int>> m;
+        size_t z = 0;
         for(size_t i = 0; i < s.length();){
             int cplen = 1;
             if((s[i] & 0xf8) == 0xf0) cplen = 4;
             else if((s[i] & 0xf0) == 0xe0) cplen = 3;
             else if((s[i] & 0xe0) == 0xc0) cplen = 2;
             if((i + cplen) > s.length()) cplen = 1;
-            v[x++] = s.substr(i, cplen);
+            m[z++] = make_pair(i, cplen);
             i += cplen;
         }
-        char_cache[id] = v;
+        utf8cache[id] = m;
     }
-    return char_cache[id][ipos];
+    pair<int, int> p = utf8cache[id][ipos];
+    return s.substr(p.first, p.second);
 }
 
 //Convert ldpl_number to LDPL string, killing trailing 0's

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -179,8 +179,8 @@ ldpl_number get_char_num(const string & chr){
 unordered_map<size_t, ldpl_vector<string>> char_cache;
 string charat(const string & s, ldpl_number pos) {
     unsigned int ipos = floor(pos);
-    size_t hash = std::hash<string>{}(s);
-    if(char_cache.find(hash)==char_cache.end()){
+    size_t id = (size_t)&s;
+    if(char_cache.find(id)==char_cache.end()){
         ldpl_vector<string> v;
         ldpl_number x = 0;
         for(size_t i = 0; i < s.length();){
@@ -192,9 +192,9 @@ string charat(const string & s, ldpl_number pos) {
             v[x++] = s.substr(i, cplen);
             i += cplen;
         }
-        char_cache[hash] = v;
+        char_cache[id] = v;
     }
-    return char_cache[hash][ipos];
+    return char_cache[id][ipos];
 }
 
 //Convert ldpl_number to LDPL string, killing trailing 0's

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -180,7 +180,7 @@ ldpl_number get_char_num(const string & chr){
 unordered_map<size_t, unordered_map<size_t, pair<int, int>>> utf8cache;
 string charat(const string& s, ldpl_number pos) {
     unsigned int ipos = floor(pos);
-    size_t id = (size_t)&s;
+    size_t id = (size_t)&s << s.size();
     if(utf8cache.find(id)==utf8cache.end()){
         unordered_map<size_t, pair<int, int>> m;
         size_t z = 0;


### PR DESCRIPTION
These are two little "optimizations" that, under some circumstances, make LDPL a lot faster when working with text.

I was trying to parse a big file using LDPL, one character at a time, but it was going kinda slow. So I started tracking down where time was spent, and it looked like it was mainly in two function: `join()` and `utf8_substr()`.

The first thing I did was run some benchmarks. It looked like `a += b` was a heck of a lot faster than `join(a, b, a)`, so I made the compiler special case any concat-style joins.

The second one is kinda nutty: Every time you call `GET CHARACTER AT - FROM - IN`, the whole string has to be searched starting at the beginning and all the positions of all the characters have to be re-discovered. Because of the variable widths of characters in utf8. Kind of a necessary evil, since it's so nice that LDPL supports utf8! But it means if you call `get character at 1000 from $filetext in var` then `get character at 1001 from $filetext in var`, and so on in a loop, each call is re-discovering the string and going through all 1000+ characters to find the one you asked for. It's like that movie Memento - everyone is always getting re-introduced! For big files, this can really get sluggish.

So, I added a little `utf8cache` inside `charat()` that maps positions of characters to their utf8 code points the first time a search is done on a string. This means the `get` in the loop basically becomes a constant time lookup, instead of O(whatever^n). There might still be some issues with how I compute the string id but it seems to work okay. All the tests pass and all the examples seem to work, as well as my projects.

I started getting a benchmark ready of the slowness, but I had to bail after 30 minutes:

### LDPL 3.0.4 -- 10 runs

```
$ time ./slow-bin 
*** STARTING TEST ***************************************************
> performing 10 runs
^C

real    30m29.856s
user    30m26.815s
sys 0m1.417s
```

So I ran it again with just 1 run and it took a minute:

### LDPL 3.0.4 -- 1 run

```
$ ./slow-bin
*** STARTING TEST ***************************************************
> performing 1 runs
> looped 146720 times (1 runs of 146720 chars)
> took 67 seconds
*************************************************** TEST COMPLETE ***
```

### LDPL w/ character cache

Now here's the benchmark with this patch, starting out with 10 runs:

```
$ ./slow-bin 10
*** STARTING TEST ***************************************************
> performing 10 runs
> looped 3408240 times (10 runs of 340824 chars)
> took 1 seconds
*************************************************** TEST COMPLETE ***
```

So yes, much faster, but a crazy approach. And maybe it'll be slower for small strings? But it's made gild a lot faster, for one, which has been nice. 

You can run the benchmark by cloning this gist and running `slow.ldpl`: https://gist.github.com/dvkt/443f5ddebe24e0fe406c051bee19cf3e

Any other ideas for how to speed up the lookup? Seems like most people use a big utf8 library which I didn't want to bring it. The cache could be improved too though.
