### PR TITLE
SPLIT text statement

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -980,16 +980,15 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         //C Code
         //TODO
         return;
-    }
-    if(line_like("SPLIT $str-expr BY $str-expr IN $str-vector", tokens, state))
+    }*/
+    if(line_like("SPLIT $str-expr BY $str-expr IN $str-vec", tokens, state))
     {
         if(state.section_state != 2)
             error("SPLIT statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        //TODO
+        state.add_code(get_c_variable(state, tokens[5]) + " = utf8_split(" + get_c_expression(state, tokens[1]) + ", " + get_c_expression(state, tokens[3]) + ");");
         return;
     }
-*/
 
     error("Malformed statement (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
 }
@@ -1071,6 +1070,14 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
         else if(model_tokens[i] == "$var") //$var is either a NUMBER variable or a TEXT variable
         {
             if(!is_variable(tokens[j], state)) return false;
+        }
+        else if(model_tokens[i] == "$num-vec") //$num-vec is NUMBER vector
+        {
+            if(!is_num_vector(tokens[j], state)) return false;
+        }
+        else if(model_tokens[i] == "$str-vec") //$str-vec is TEXT vector
+        {
+            if(!is_txt_vector(tokens[j], state)) return false;
         }
         else if(model_tokens[i] == "$literal") //$literal is either a NUMBER or a TEXT
         {

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -100,6 +100,8 @@ bool is_variable(string & token, compiler_state & state);
 bool is_num_expr(string & token, compiler_state & state);
 bool is_txt_expr(string & token, compiler_state & state);
 bool is_expression(string & token, compiler_state & state);
+bool is_num_vector(string & token, compiler_state & state);
+bool is_txt_vector(string & token, compiler_state & state);
 bool is_external(string & token, compiler_state & state);
 bool variable_exists(string & token, compiler_state & state);
 bool is_subprocedure(string & token, compiler_state & state);

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -181,6 +181,25 @@ string charat(const string & s, ldpl_number pos){
     return utf8_substr(s, pos, 1);
 }
 
+ldpl_vector<string> utf8_split(const string & s, const string & sep){
+    ldpl_vector<string> v;
+    unsigned int z = 0;
+    for(unsigned int i = 0; i < s.length();){
+        int cplen = 1;
+        int c = s[i];
+        if      (c>=0 && c<=127)     cplen=1;
+        else if ((c & 0xE0) == 0xC0) cplen=2;
+        else if ((c & 0xF0) == 0xE0) cplen=3;
+        else if ((c & 0xF8) == 0xF0) cplen=4;
+        string cp = s.substr(i, cplen);
+        if(sep.empty()) v[z++] = cp;
+        else if(sep == cp) ++z;
+        else v[z] += cp;
+        i+=cplen;
+    }
+    return v;
+}
+
 //Convert ldpl_number to LDPL string, killing trailing 0's
 //https://stackoverflow.com/questions/16605967/ & https://stackoverflow.com/questions/13686482/
 string to_ldpl_string(ldpl_number x){


### PR DESCRIPTION
This is much nicer than #93. This patch implements the `SPLIT` statement that was already listed as a `TODO` in the source. It lets you easily just split a string or file into a vector and loop over that, and avoids all the caching nonsense.

```
DATA:
words is text vector
PROCEDURE:
SPLIT "hi there" BY " " IN words
DISPLAY words:1 crlf
```
output:
```
there
```

If you want to get all the characters, you can split by `""`:

```
SPLIT "hi there" BY "" IN letters
DISPLAY letters:1 crlf
```
output:
```
i
```

And of course, the whole point - it works with utf8:
```
split "🐈 say meow, 🐕 say woof" by "" in letters
display letters:0 crlf
display letters:6 letters:7 letters:8 letters:9 crlf
display letters:12 crlf
```
output:
```
🐈
meow
🐕
```