### PR TITLE
REPLACE statement

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -956,15 +956,16 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         return;
     }
 
-/*  TODO: Implement
-    if(line_like("REPLACE $str-var FROM $str-expr WITH $str-expr IN $str-var", tokens, state))
+    if(line_like("REPLACE $str-expr FROM $str-expr WITH $str-expr IN $str-var", tokens, state))
     {
         if(state.section_state != 2)
             error("REPLACE statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        //TODO
+        state.add_code(get_c_variable(state, tokens[7]) + " = str_replace(" + get_c_expression(state, tokens[3]) + ", " + get_c_expression(state, tokens[1]) + ", " + get_c_expression(state, tokens[5]) + ");");
         return;
     }
+
+/*  TODO: Implement
     if(line_like("GET INDEX OF $str-expr FROM $str-expr IN $num-var", tokens, state))
     {
         if(state.section_state != 2)

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -103,6 +103,25 @@ void join(const string & a, const string & b, string & c){
     c = a + b;
 }
 
+ldpl_vector<string> utf8_split(const string & s, const string & sep){
+    ldpl_vector<string> v;
+    unsigned int z = 0;
+    for(unsigned int i = 0; i < s.length();){
+        int cplen = 1;
+        int c = s[i];
+        if      (c>=0 && c<=127)     cplen=1;
+        else if ((c & 0xE0) == 0xC0) cplen=2;
+        else if ((c & 0xF0) == 0xE0) cplen=3;
+        else if ((c & 0xF8) == 0xF0) cplen=4;
+        string cp = s.substr(i, cplen);
+        if(sep.empty()) v[z++] = cp;
+        else if(sep == cp) ++z;
+        else v[z] += cp;
+        i+=cplen;
+    }
+    return v;
+}
+
 //http://www.zedwood.com/article/cpp-utf8-strlen-function
 int utf8_strlen(const string& str)
 {
@@ -179,25 +198,6 @@ ldpl_number get_char_num(const string & chr){
 string charat(const string & s, ldpl_number pos){
     unsigned int _pos = floor(pos);
     return utf8_substr(s, pos, 1);
-}
-
-ldpl_vector<string> utf8_split(const string & s, const string & sep){
-    ldpl_vector<string> v;
-    unsigned int z = 0;
-    for(unsigned int i = 0; i < s.length();){
-        int cplen = 1;
-        int c = s[i];
-        if      (c>=0 && c<=127)     cplen=1;
-        else if ((c & 0xE0) == 0xC0) cplen=2;
-        else if ((c & 0xF0) == 0xE0) cplen=3;
-        else if ((c & 0xF8) == 0xF0) cplen=4;
-        string cp = s.substr(i, cplen);
-        if(sep.empty()) v[z++] = cp;
-        else if(sep == cp) ++z;
-        else v[z] += cp;
-        i+=cplen;
-    }
-    return v;
 }
 
 //Convert ldpl_number to LDPL string, killing trailing 0's

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -178,6 +178,20 @@ string utf8_substr(const string &str,int start, int length=INT_MAX)
     return str.substr(realstart,reallength);
 }
 
+//https://stackoverflow.com/a/27658515
+string str_replace(string const& s, string const& find, string const& replace){
+    string result;
+    size_t find_len = find.size();
+    size_t pos, from=0;
+    while (string::npos != (pos=s.find(find,from))){
+        result.append(s, from, pos-from);
+        result.append(replace);
+        from = pos + find_len;
+    }
+    result.append(s, from , string::npos);
+    return result;
+}
+
 ldpl_number str_len(const string & a){
     return utf8_strlen(a);
 }


### PR DESCRIPTION
This adds the REPLACE statement, which as an unimplemented TODO in the source:

```
REPLACE $str-expr FROM $str-expr WITH $str-expr IN $str-var
```

example:
```
DATA:
string IS text
PROCEDURE:
STORE "Please reject this Pull Request." IN string
REPLACE "reject" FROM string WITH "accept" IN string
DISPLAY string crlf
REPLACE "Pull Request" FROM string WITH "lizard" IN string
REPLACE "accept" FROM string WITH "admire" IN string
REPLACE "." FROM string WITH ": 🦎" IN string
DISPLAY string crlf
```
output:
```
Please accept this Pull Request.
Please admire this lizard: 🦎
```