### PR TITLE
Fix exit code on BSD/Mac

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -916,8 +916,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state != 2)
             error("EXECUTE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
-        state.add_code(get_c_variable(state, tokens[7]) + " = system(" + get_c_char_array(state, tokens[1]) + ");");
-        state.add_code(get_c_variable(state, tokens[7]) + " = WEXITSTATUS((int)" + get_c_variable(state, tokens[7]) + ");");
+        state.add_code(get_c_variable(state, tokens[7]) + " = (system(" + get_c_char_array(state, tokens[1]) + ") >> 8) & 0xff;"); //shift wait() val and get lowest 2
         return;
     }
     if(line_like("ACCEPT $str-var UNTIL EOF", tokens, state))

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -917,7 +917,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
             error("EXECUTE outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
         state.add_code(get_c_variable(state, tokens[7]) + " = system(" + get_c_char_array(state, tokens[1]) + ");");
-        state.add_code(get_c_variable(state, tokens[7]) + " = WEXITSTATUS(" + get_c_variable(state, tokens[7]) + ");");
+        state.add_code(get_c_variable(state, tokens[7]) + " = WEXITSTATUS((int)" + get_c_variable(state, tokens[7]) + ");");
         return;
     }
     if(line_like("ACCEPT $str-var UNTIL EOF", tokens, state))

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -15,6 +15,10 @@
 #define ldpl_number double
 #define CRLF \"\\n\"
 
+//Fix WEXITSTATUS on BSD by ignoring wait() unions.
+#undef _W_INT
+#define _W_INT(x) ((int)x)
+
 using namespace std;
 
 //Global variables

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -15,10 +15,6 @@
 #define ldpl_number double
 #define CRLF \"\\n\"
 
-//Fix WEXITSTATUS on BSD by ignoring wait() unions.
-#undef _W_INT
-#define _W_INT(x) ((int)x)
-
 using namespace std;
 
 //Global variables


### PR DESCRIPTION
Continuing the conversation from 3f5325a613435b9ac478a9bfc4b002537d5e5084...

Currently on `master,` the exit code for `EXECUTE - AND STORE EXIT CODE IN` is always 0. I did some digging and it looks like BSD has a different WEXITSTATUS() macro than Linux:

> OpenBSD's implementation of WEXITSTATUS uses the address-of operator (unary &) on its argument, effectively requiring that its argument have storage. You are calling it with the return value of a function, which doesn't have storage, so the compiler complains. - https://stackoverflow.com/a/13674801

Here's BSD/Mac's: 

https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/sys/wait.h#L144

Which uses the `_W_INT` macro:

https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/bsd/sys/wait.h#L128

And glibc's, which doesn't:

https://github.com/bminor/glibc/blob/7628a1b05adb1e4c6857b87c6f8b71a1d0b1d72c/posix/sys/wait.h#L54

https://github.com/bminor/glibc/blob/7628a1b05adb1e4c6857b87c6f8b71a1d0b1d72c/bits/waitstatus.h#L28

I tried a few things but I suspect the most portable would just be to overwrite `_W_INT` if it exists to do what we want. Sounds like only really old code expects wait() to return a union on BSDs, anyway.

I also added the explicit `(int)` cast which my Linux machines needed, for some reason.
