### PR TITLE
Lists

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -430,6 +430,32 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.add_var_code("ldpl_vector<string> " + fix_identifier(tokens[0], true) + ";");
         return;
     }
+    if(line_like("$name IS NUMBER LIST", tokens, state))
+    {
+        if(state.section_state != 1)
+            error("Variable declaration outside DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        if(!variable_exists(tokens[0], state)){
+            state.variables[tokens[0]] = 5;
+        }
+        else
+            error("Duplicate declaration for variable " + tokens[0] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_var_code("ldpl_list<ldpl_number> " + fix_identifier(tokens[0], true) + ";");
+        return;
+    }
+    if(line_like("$name IS TEXT LIST", tokens, state))
+    {
+        if(state.section_state != 1)
+            error("Variable declaration outside DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        if(!variable_exists(tokens[0], state)){
+            state.variables[tokens[0]] = 6;
+        }
+        else
+            error("Duplicate declaration for variable " + tokens[0] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_var_code("ldpl_list<string> " + fix_identifier(tokens[0], true) + ";");
+        return;
+    }
     if(line_like("$name IS EXTERNAL NUMBER", tokens, state))
     {
         if(state.section_state != 1)
@@ -1013,7 +1039,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.add_code(get_c_variable(state, tokens[1]) + ".clear();");
         return;
     }
-    if(line_like("COPY $str-vec TO $str-vec", tokens, state)) //TODO these COPY statements should be mixed into one that allow cross copying.
+    if(line_like("COPY $str-vec TO $str-vec", tokens, state))
     {
         if(state.section_state != 2)
             error("COPY statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
@@ -1043,6 +1069,63 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
             error("STORE INDICES statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
         state.add_code("get_indices(" + get_c_variable(state, tokens[5]) + ", " + get_c_variable(state, tokens[3]) + ");");
+        return;
+    }
+    if(line_like("PUSH $num-expr TO $num-list", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("PUSH statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_code(get_c_variable(state, tokens[3]) + ".push_back(" + get_c_expression(state, tokens[1]) + ");");
+        return;
+    }
+    if(line_like("CLEAR $list", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("CLEAR statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_code(get_c_variable(state, tokens[1]) + ".clear();");
+        return;
+    }
+    if(line_like("STORE LENGTH OF $list IN $num-var", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("STORE LENGTH OF (list) statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_code(get_c_variable(state, tokens[5]) + " = " + get_c_variable(state, tokens[3]) + ".size();");
+        return;
+    }
+    if(line_like("DELETE LAST ELEMENT OF $list", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("DELETE LAST ELEMENT OF statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_code("if(" + get_c_variable(state, tokens[4]) + ".size() > 0)");
+        state.add_code(get_c_variable(state, tokens[4]) + ".pop_back();");
+        return;
+    }
+    if(line_like("COPY $str-list TO $str-list", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("COPY statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_code(get_c_variable(state, tokens[3]) + " = " + get_c_variable(state, tokens[1]) + ";");
+        return;
+    }
+    if(line_like("COPY $num-list TO $num-list", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("COPY statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_code(get_c_variable(state, tokens[3]) + " = " + get_c_variable(state, tokens[1]) + ";");
+        return;
+    }
+    if(line_like("SPLIT $str-expr BY $str-expr IN $str-list", tokens, state))
+    {
+        if(state.section_state != 2)
+            error("SPLIT statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        //C Code
+        state.add_code(get_c_variable(state, tokens[5]) + " = utf8_split_list(" + get_c_expression(state, tokens[1]) + ", " + get_c_expression(state, tokens[3]) + ");");
         return;
     }
 
@@ -1138,6 +1221,17 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
         {
             if(!is_txt_vector(tokens[j], state)) return false;
         }
+        else if(model_tokens[i] == "$list"){ //$list is a LIST
+            if(!is_num_list(tokens[j], state) && !is_txt_list(tokens[j], state)) return false;
+        }
+        else if(model_tokens[i] == "$num-list") //$num-vec is NUMBER list
+        {
+            if(!is_num_list(tokens[j], state)) return false;
+        }
+        else if(model_tokens[i] == "$str-list") //$str-vec is TEXT list
+        {
+            if(!is_txt_list(tokens[j], state)) return false;
+        }
         else if(model_tokens[i] == "$literal") //$literal is either a NUMBER or a TEXT
         {
             if(!is_string(tokens[j]) && !is_number(tokens[j])) return false;
@@ -1222,6 +1316,7 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
             string second_value = tokens.rbegin()[1];
             bool text_values = false;
             bool vector_values = false;
+            bool list_values = false;
             if(is_num_expr(first_value, state) && is_num_expr(second_value, state))
                 text_values = false;
             else if(is_txt_expr(first_value, state) && is_txt_expr(second_value, state))
@@ -1230,6 +1325,10 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
                 vector_values = true;
             else if(is_txt_vector(first_value, state) && is_txt_vector(second_value, state))
                 vector_values = true;
+            else if(is_num_list(first_value, state) && is_num_list(second_value, state))
+                list_values = true;
+            else if(is_txt_list(first_value, state) && is_txt_list(second_value, state))
+                list_values = true;
             else
                 return false;
 
@@ -1242,6 +1341,7 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
             if(rel_op != "EQUAL TO " && rel_op != "NOT EQUAL TO "){
                 if(text_values) return false;
                 if(vector_values) return false;
+                if(list_values) return false;
                 if(rel_op != "GREATER THAN " && rel_op != "GREATER THAN OR EQUAL TO "
                 && rel_op != "LESS THAN " && rel_op != "LESS THAN OR EQUAL TO ")
                     return false;
@@ -1330,6 +1430,18 @@ bool is_txt_vector(string & token, compiler_state & state)
     return false;
 }
 
+bool is_num_list(string & token, compiler_state & state)
+{
+    if(state.variables.count(token) > 0 && state.variables[token] == 5) return true;
+    return false;
+}
+
+bool is_txt_list(string & token, compiler_state & state)
+{
+    if(state.variables.count(token) > 0 && state.variables[token] == 6) return true;
+    return false;
+}
+
 bool is_vector(string & token, compiler_state & state)
 {
     return is_num_vector(token, state) || is_txt_vector(token, state);
@@ -1342,7 +1454,7 @@ bool is_num_var(string & token, compiler_state & state)
     //Check if num_vector:index
     string vector, index;
     split_vector(token, vector, index);
-    return is_num_vector(vector, state) && is_expression(index, state);
+    return (is_num_vector(vector, state) || is_num_list(vector, state)) && is_expression(index, state);
 }
 
 bool is_txt_var(string & token, compiler_state & state)
@@ -1352,7 +1464,7 @@ bool is_txt_var(string & token, compiler_state & state)
     //Check if txt_vector:index
     string vector, index;
     split_vector(token, vector, index);
-    return is_txt_vector(vector, state) && index != "" && is_expression(index, state);
+    return (is_txt_vector(vector, state) || is_txt_list(vector, state)) && index != "" && is_expression(index, state);
 }
 
 bool is_variable(string & token, compiler_state & state)

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -404,7 +404,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.add_var_code("string " + fix_identifier(tokens[0], true) + " = \"\";");
         return;
     }
-    if(line_like("$name IS NUMBER VECTOR", tokens, state))
+    if(line_like("$name IS NUMBER VECTOR", tokens, state) || line_like("$name IS NUMBER MAP", tokens, state))
     {
         if(state.section_state != 1)
             error("Variable declaration outside DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
@@ -417,7 +417,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.add_var_code("ldpl_vector<ldpl_number> " + fix_identifier(tokens[0], true) + ";");
         return;
     }
-    if(line_like("$name IS TEXT VECTOR", tokens, state))
+    if(line_like("$name IS TEXT VECTOR", tokens, state) || line_like("$name IS TEXT MAP", tokens, state))
     {
         if(state.section_state != 1)
             error("Variable declaration outside DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
@@ -454,7 +454,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.externals[tokens[0]] = true;
         return;
     }
-    if(line_like("$name IS EXTERNAL NUMBER VECTOR", tokens, state))
+    if(line_like("$name IS EXTERNAL NUMBER VECTOR", tokens, state) || line_like("$name IS EXTERNAL TEXT MAP", tokens, state))
     {
         if(state.section_state != 1)
             error("Variable declaration outside DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
@@ -467,7 +467,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         state.externals[tokens[0]] = true;
         return;
     }
-    if(line_like("$name IS EXTERNAL TEXT VECTOR", tokens, state))
+    if(line_like("$name IS EXTERNAL TEXT VECTOR", tokens, state) || line_like("$name IS EXTERNAL TEXT MAP", tokens, state))
     {
         if(state.section_state != 1)
             error("Variable declaration outside DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
@@ -1008,7 +1008,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     if(line_like("CLEAR $vector", tokens, state))
     {
         if(state.section_state != 2)
-            error("CLEAR VECTOR statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+            error("CLEAR statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
         state.add_code(get_c_variable(state, tokens[1]) + ".clear();");
         return;
@@ -1032,7 +1032,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     if(line_like("STORE INDEX COUNT OF $vector IN $num-var", tokens, state))
     {
         if(state.section_state != 2)
-            error("CLEAR VECTOR statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+            error("STORE INDEX COUNT statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C Code
         state.add_code(get_c_variable(state, tokens[6]) + " = " + get_c_variable(state, tokens[4]) + ".count();");
         return;
@@ -1127,7 +1127,7 @@ bool line_like(string model_line, vector<string> & tokens, compiler_state & stat
         {
             if(!is_variable(tokens[j], state)) return false;
         }
-        else if(model_tokens[i] == "$vector"){ //$vector is TEXT VECTOR, NUMBER VECTOR
+        else if(model_tokens[i] == "$vector"){ //$vector is TEXT MAP, NUMBER MAP
             if(!is_num_vector(tokens[j], state) && !is_txt_vector(tokens[j], state)) return false;
         }
         else if(model_tokens[i] == "$num-vec") //$num-vec is NUMBER vector
@@ -1389,7 +1389,7 @@ void split_vector(string & token, string & vector, string & index)
         //Bear in mind that if we are storing a value in vector:"",
         //this means that index will contain "\"\"", and not "".
     } else if (pos == token.size() - 1)
-        error("Incomplete VECTOR access found (can't end on ':'!).");
+        error("Incomplete MAP or ARRAY access found (can't end on ':'!).");
     else{
         vector = token.substr(0, pos);
         index = token.substr(pos+1);

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -33,7 +33,7 @@ struct compiler_state{
     //variables
     map<string, unsigned int> variables;
     map<string, bool> externals; //variables defined in c++ extensions
-    //1 number, 2 text, 3 number vector, 4 text vector
+    //1 number, 2 text, 3 number map/vector, 4 text map/vector, 5 number list, 6 text list
     vector<string> subprocedures;
     void add_var_code(string code){
         this->variable_code.push_back(code);
@@ -107,6 +107,8 @@ bool is_txt_expr(string & token, compiler_state & state);
 bool is_expression(string & token, compiler_state & state);
 bool is_num_vector(string & token, compiler_state & state);
 bool is_txt_vector(string & token, compiler_state & state);
+bool is_num_list(string & token, compiler_state & state);
+bool is_txt_list(string & token, compiler_state & state);
 bool is_external(string & token, compiler_state & state);
 bool variable_exists(string & token, compiler_state & state);
 bool is_subprocedure(string & token, compiler_state & state);

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -10,11 +10,13 @@
 #include <chrono>
 #include <thread>
 #include <time.h>
+#include <vector>
 
 #define NVM_FLOAT_EPSILON 0.00000001
 #define ldpl_number double
 #define CRLF \"\\n\"
 #define ldpl_vector ldpl_map 
+#define ldpl_list vector
 
 using namespace std;
 
@@ -143,6 +145,30 @@ ldpl_vector<string> utf8_split(const string & s, const string & sep){
         else v[z] += cp;
         i+=cplen;
     }
+    return v;
+}
+
+ldpl_list<string> utf8_split_list(const string & s, const string & sep){
+    ldpl_list<string> v;
+    unsigned int z = 0;
+    string current_token = \"\";
+    for(unsigned int i = 0; i < s.length();){
+        int cplen = 1;
+        int c = s[i];
+        if      (c>=0 && c<=127)     cplen=1;
+        else if ((c & 0xE0) == 0xC0) cplen=2;
+        else if ((c & 0xF0) == 0xE0) cplen=3;
+        else if ((c & 0xF8) == 0xF0) cplen=4;
+        string cp = s.substr(i, cplen); //Current char
+        if(sep == cp){
+            if(current_token.size() > 0) v.push_back(current_token);
+            current_token = \"\";
+        }else{
+            current_token += cp;
+        }
+        i+=cplen;
+    }
+    if(current_token.size() > 0) v.push_back(current_token);
     return v;
 }
 

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -14,6 +14,7 @@
 #define NVM_FLOAT_EPSILON 0.00000001
 #define ldpl_number double
 #define CRLF \"\\n\"
+#define ldpl_vector ldpl_map 
 
 using namespace std;
 
@@ -29,7 +30,7 @@ string VAR_ERRORTEXT = \"\";
 string to_ldpl_string(double x);
 
 template<typename T>
-struct ldpl_vector {
+struct ldpl_map {
     unordered_map<string, T> inner_map;
 
     T& operator [] (const string& i) {


### PR DESCRIPTION
I've added `LIST`s to the language. LISTs work like C++ vectors do, they have a defined size, one can push elements to these lists, access, read and write to its indices, clear them, copy them, compare them and split strings into them. I've felt for a long time now that LDPL Vectors are not only not enough but might be confusing and counterproductive to use in some situations, so here we have lists. Also, as LDPL Vectors are, in fact, what common languages use to call "Maps" or "Dictionaries", one can now use `foo IS NUMBER MAP` instead of `foo IS NUMBER VECTOR` (the later still works for compatibility, but will be marked as deprecated in the documentation).

Please tell me what you think about this update. I'll add everything to the docs as soon as I can.
@dvkt @dgarroDC 