### PR TITLE
temporary cpp file is now deleted correctly on windows

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -190,7 +190,11 @@ int main(int argc, const char* argv[])
         for(string & extension : extensions) compile_line += " "+extension;
     }
     int compiled = system(compile_line.c_str());
-    system("rm ldpl-temp.cpp");
+    #if defined(_WIN32)
+        system("del ldpl-temp.cpp");
+    #else
+        system("rm ldpl-temp.cpp");
+    #endif
     if(compiled == 0){
         cout << "*\033[32;1m File(s) compiled successfully.\033[0m" << endl;
         cout << "* Saved as " << final_filename << endl;


### PR DESCRIPTION
in order to delete the temporary cpp file (`ldpl-temp.cpp`) the compiler called the `rm` system command.
windows does not have this command, and instead has `del`.
I added a simple preprocessor check that will use `del` on windows and `rm` on everything else.