### PR TITLE
PARAMETERS, LOCAL DATA & CREATE STATEMENT

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1849,7 +1849,7 @@ void add_call_code(string & subprocedure, vector<string> & parameters, compiler_
         if (is_number(parameters[i]) || is_string(parameters[i])) {
             // C++ doen't allow passing literals in  reference parameters, we create vars for them
             string literal_paramater_var = state.new_literal_parameter_var();
-            state.add_code(is_number(parameters[i]) ? "ldpl_number " : "string "
+            state.add_code((is_number(parameters[i]) ? "ldpl_number " : "string ")
                            + literal_paramater_var + " = " + parameters[i] + ";");
             code += literal_paramater_var;
         } else {

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -713,7 +713,14 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
                     types.push_back("ldpl_vector<string>");
                 else if(is_txt_list(tokens[i], state))
                     types.push_back("ldpl_list<string>");
-                code += get_c_expression(state, tokens[i]);
+                if (is_number(tokens[i]) || is_string(tokens[i])) {
+                    // C++ doen't allow passing literals in  reference parameters, we create vars for them
+                    string literal_paramter_var = state.new_literal_parameter_var();
+                    state.add_code(types.back() + " " + literal_paramter_var + " = " + tokens[i] + ";");
+                    code += literal_paramter_var;
+                } else {
+                    code += get_c_variable(state, tokens[i]);
+                }
                 if (i < tokens.size() - 1) code += ", ";
             }
             bool correct_types = state.correct_subprocedure_types(name, types);

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -433,7 +433,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state == 2)
             error("Duplicate PROCEDURE section declaration (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         state.section_state = 2;
-        if (state.current_subprocedure != "") open_subprocedure_code(state, line_num, current_file);
+        if (state.current_subprocedure != "" && state.section_state >= 3) open_subprocedure_code(state, line_num, current_file);
         return;
     }
     if(line_like("PARAMETERS:", tokens, state))
@@ -458,6 +458,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(state.section_state == 2)
             error("LOCAL DATA section declaration within PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         state.section_state = 1;
+        open_subprocedure_code(state, line_num, current_file);
         return;
     }
 

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -432,8 +432,9 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state == 2)
             error("Duplicate PROCEDURE section declaration (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        if (state.current_subprocedure != "" && state.section_state >= 3)
+            open_subprocedure_code(state, line_num, current_file);
         state.section_state = 2;
-        if (state.current_subprocedure != "" && state.section_state >= 3) open_subprocedure_code(state, line_num, current_file);
         return;
     }
     if(line_like("PARAMETERS:", tokens, state))

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -468,7 +468,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
     {
         if(state.section_state != 1 && state.section_state != 4)
             error("Variable declaration outside DATA, PARAMETERS or LOCAL DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        if(variable_exists(tokens[0], state))
+        if(state.variables[state.current_subprocedure].count(tokens[0]) > 0)
             error("Duplicate declaration for variable " + tokens[0] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         if(tokens.size() > 5)
             error("Invalid type for variable " + tokens[0] + " (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -501,7 +501,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
                 valid_type = false;
             }
         }
-        if (valid_type) {
+        if (valid_type && i >= tokens.size() - 1) {
             if(state.section_state != 1 && state.section_state != 4)
                 error("Variable declaration outside DATA, PARAMETERS or LOCAL DATA section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
             if(state.variables[state.current_subprocedure].count(tokens[0]) > 0)

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -719,6 +719,8 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
                     types.push_back("ldpl_vector<string>");
                 else if(is_txt_list(parameter, state))
                     types.push_back("ldpl_list<string>");
+                else
+                    error("CALL with invalid parameter \"" + parameter + "\" (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
             }
             bool correct_types = state.correct_subprocedure_types(subprocedure, types);
             if(!is_subprocedure(subprocedure, state)) {

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1217,7 +1217,7 @@ string fix_identifier(string ident, bool isVar, compiler_state & state){
         return fix_external_identifier(ident, isVar);
     }else{
         string local_prefix = ""; // Used for PARAMETERS and LOCAL DATA variables
-        if (isVar && state.current_subprocedure != "")
+        if (isVar && state.variables[""].count(ident) == 0)
             local_prefix = "LVAR_" + fix_identifier(state.current_subprocedure, false) + "_";
         return local_prefix + fix_identifier(ident, isVar);
     }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1257,20 +1257,20 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
                 ++param_count;
                 if (param_count > parameters.size()) break;
                 if (parameters[param_count-1].first == "ldpl_number")
-                    model_line += "$num-expr";
+                    model_line += "$num-expr ";
                 else if (parameters[param_count-1].first == "string")
-                    model_line += "$str-expr";
+                    model_line += "$str-expr ";
                 else if (parameters[param_count-1].first == "ldpl_vector<ldpl_number>")
-                    model_line += "$num-vec";
+                    model_line += "$num-vec ";
                 else if (parameters[param_count-1].first == "ldpl_list<ldpl_number>")
-                    model_line += "$num-list";
+                    model_line += "$num-list ";
                 else if (parameters[param_count-1].first == "ldpl_vector<string>")
-                    model_line += "$str-vec";
+                    model_line += "$str-vec ";
                 else if (parameters[param_count-1].first == "ldpl_list<string>")
-                    model_line += "$str-list";
+                    model_line += "$str-list ";
             } else if (token.find_first_not_of(valid_keyword_chars) == string::npos) {
                 ++keyword_count;
-                model_line += token;
+                model_line += token + " ";
             } else {
                 error("CREATE STATEMENT with invalid token \"" + token + "\" (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
             }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1221,26 +1221,37 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         vector<pair<string, string>> parameters = state.subprocedures[tokens[4]];
         trim(model_line);
         tokenize(model_line, 0, model_tokens, state.current_file, true);
-        if ((size_t)count(model_tokens.begin(), model_tokens.end(), "$") != parameters.size())
-            error("CREATE STATEMENT parameters count doesn't match SUB-PROCEDURE (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
-        size_t i = 0;
-        for (string & token : model_tokens) if (token == "$") {
-            if (parameters[i].first == "ldpl_number")
-                token = "$num-expr";
-            else if (parameters[i].first == "string")
-                token = "$str-expr";
-            else if (parameters[i].first == "ldpl_vector<ldpl_number>")
-                token = "$num-vec";
-            else if (parameters[i].first == "ldpl_list<ldpl_number>")
-                token = "$num-list";
-            else if (parameters[i].first == "ldpl_vector<string>")
-                token = "$str-vec";
-            else if (parameters[i].first == "ldpl_list<string>")
-                token = "$str-list";
-            i++;
-        }
+        size_t param_count = 0;
+        size_t keyword_count = 0;
+        string valid_keyword_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         model_line = "";
-        for (i = 0; i < model_tokens.size(); i++) model_line += model_tokens[i] + " ";
+        for (string & token : model_tokens) {
+            if (token == "$") {
+                ++param_count;
+                if (param_count > parameters.size()) break;
+                if (parameters[param_count-1].first == "ldpl_number")
+                    model_line += "$num-expr";
+                else if (parameters[param_count-1].first == "string")
+                    model_line += "$str-expr";
+                else if (parameters[param_count-1].first == "ldpl_vector<ldpl_number>")
+                    model_line += "$num-vec";
+                else if (parameters[param_count-1].first == "ldpl_list<ldpl_number>")
+                    model_line += "$num-list";
+                else if (parameters[param_count-1].first == "ldpl_vector<string>")
+                    model_line += "$str-vec";
+                else if (parameters[param_count-1].first == "ldpl_list<string>")
+                    model_line += "$str-list";
+            } else if (token.find_first_not_of(valid_keyword_chars) == string::npos) {
+                ++keyword_count;
+                model_line += token;
+            } else {
+                error("CREATE STATEMENT with invalid token \"" + token + "\" (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+            }
+        }
+        if (param_count != parameters.size())
+            error("CREATE STATEMENT parameters count doesn't match SUB-PROCEDURE (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
+        if (keyword_count == 0)
+            error("CREATE STATEMENT without keywords (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         state.custom_statements.emplace_back(model_line, tokens[4]);
         return;
     }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -505,9 +505,13 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
             }
         }
         string identifier = fix_identifier(tokens[0], true, state);
-        if (state.section_state == 1) // DATA or LOCAL DATA
-            state.add_var_code(extern_keyword + type + " " + identifier + assign_default +  ";");
-        else // PARAMETERS
+        if (state.section_state == 1) { // DATA or LOCAL DATA
+            string code = extern_keyword + type + " " + identifier + assign_default + ";";
+            if (state.current_subprocedure == "") // DATA
+                state.add_var_code(code);
+            else
+                state.add_code(code); // LOCAL DATA
+        } else // PARAMETERS
             state.subprocedures[state.current_subprocedure].emplace_back(type, identifier);
         return;
     }
@@ -1259,10 +1263,7 @@ string fix_identifier(string ident, bool isVar, compiler_state & state){
     if(is_external(ident, state)){
         return fix_external_identifier(ident, isVar);
     }else{
-        string local_prefix = ""; // Used for PARAMETERS and LOCAL DATA variables
-        if (isVar && state.variables[""].count(ident) == 0)
-            local_prefix = "LVAR_" + fix_identifier(state.current_subprocedure, false) + "_";
-        return local_prefix + fix_identifier(ident, isVar);
+        return fix_identifier(ident, isVar);
     }
 }
 

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -24,7 +24,7 @@ using namespace std;
 //TODO: Change vectors to maps
 struct compiler_state{
     unsigned int section_state = 0;
-    //0 no section, 1 data, 2 procedure, 3 sub-procedure start, 4 parameters, 5 local data
+    //0 no section, 1 data or local, 2 procedure, 3 sub-procedure start, 4 parameters
     unsigned int current_line = 0;
     string current_file = "";
     //Code to output (plain C code)
@@ -32,7 +32,7 @@ struct compiler_state{
     vector<string> output_code;
     vector<string> subroutine_code; //code outside main()
     //variables
-    map<string, unsigned int> variables;
+    map<string, map<string, unsigned int>> variables; //variables by subprocedure (or "" for main)
     map<string, bool> externals; //variables defined in c++ extensions
     //1 number, 2 text, 3 number map/vector, 4 text map/vector, 5 number list, 6 text list
     vector<string> subprocedures;
@@ -149,3 +149,4 @@ string fix_identifier(string id, bool isv, compiler_state & s);
 string fix_identifier(string identifier, bool isVariable);
 string fix_identifier(string identifier);
 bool in_procedure_section(compiler_state & state);
+unsigned int variable_type(string & token, compiler_state & state);

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -23,7 +23,8 @@ using namespace std;
 
 //TODO: Change vectors to maps
 struct compiler_state{
-    unsigned int section_state = 0; //0 no section, 1 data, 2 procedure
+    unsigned int section_state = 0;
+    //0 no section, 1 data, 2 procedure, 3 sub-procedure start, 4 parameters, 5 local data
     unsigned int current_line = 0;
     string current_file = "";
     //Code to output (plain C code)
@@ -39,21 +40,21 @@ struct compiler_state{
         this->variable_code.push_back(code);
     }
     void add_code(string code){
-        if(!in_subprocedure)
+        if(current_subprocedure == "")
             this->output_code.push_back(code);
         else
             this->subroutine_code.push_back(code);
     }
     bool open_quote = false;
-    bool in_subprocedure = false;
+    string current_subprocedure = "";
     int open_loops = 0;
     stack<int> block_stack; //0 sub-procedure, 1 if or else if, 2 while/for, 3 else
-    void open_subprocedure(){
-        in_subprocedure = true;
+    void open_subprocedure(string & subprocedure){
+        current_subprocedure = subprocedure;
         block_stack.push(0);
     }
     void close_subprocedure(){
-        in_subprocedure = false;
+        current_subprocedure = "";
         block_stack.pop();
     }
     bool closing_subprocedure(){
@@ -147,3 +148,4 @@ string fix_external_identifier(string identifier, bool isVariable);
 string fix_identifier(string id, bool isv, compiler_state & s);
 string fix_identifier(string identifier, bool isVariable);
 string fix_identifier(string identifier);
+bool in_procedure_section(compiler_state & state);

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -91,6 +91,11 @@ struct compiler_state{
     string new_range_var(){
         return "RVAR_" + to_string(range_vars++);
     }
+    //We keep track of declared variables used to pass literal parameters
+    int literal_paramter_vars = 0;
+    string new_literal_parameter_var(){
+        return "LPVAR_" + to_string(literal_paramter_vars++);
+    }
     //Adds a subprocedure that has been called but hasn't been declared.
     //If it hasn't been declared when compilation reaches the end of the source,
     //an error is risen.

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -130,6 +130,7 @@ struct compiler_state{
         return true;
     }
     stack<string> working_dir;
+    vector<pair<string, string>> custom_statements; // (statement model line, subprocedure name)
 };
 
 void bullet_msg(const string & msg);
@@ -177,3 +178,4 @@ string fix_identifier(string identifier);
 bool in_procedure_section(compiler_state & state, unsigned int line_num, string & current_file);
 unsigned int variable_type(string & token, compiler_state & state);
 void open_subprocedure_code(compiler_state & state, unsigned int line_num, string & current_file);
+void add_call_code(string & subprocedure, vector<string> & parameters, compiler_state & state, unsigned int line_num);


### PR DESCRIPTION
This resolves #113. Currently only `LOCAL DATA` section is implemented for now, I'll implement `PARAMETERS` later, you can review and test the code in the meantime.

Example:

```
DATA:
  x is number
PROCEDURE:
  sub-procedure foo
    LOCAL DATA:
      i is number
    PROCEDURE:
      incr i
      display "FOO " i crlf
  end sub-procedure
  sub-procedure bar
    LOCAL DATA:
      i is text
    PROCEDURE:
       join i and "-" in i
      display "BAR " i crlf
  end sub-procedure
  for x from 0 to 10 step 1 do
    call foo
    call bar
  repeat
```

Output:

```
FOO 1
BAR -
FOO 2
BAR --
FOO 3
BAR ---
FOO 4
BAR ----
FOO 5
BAR -----
FOO 6
BAR ------
FOO 7
BAR -------
FOO 8
BAR --------
FOO 9
BAR ---------
FOO 10
BAR ----------
```

All the variable declaration statements where merged to only one if to reduce duplicated code.

We store in which subprocedure a variable was declared and when we expect some variable we search it in the current subprocedure and main variables. The function `variable_type` handles this.

To keep the variable values persistent, we fix the C++ identifier based on the subprocedure (for example, `LVAR_SUBPR_FOO_VAR_I`) and declare it as a global variable.

The `PROCEDURE:` label is optional if the subprocedure only has procedure statements. This was implemented with the `in_procedure_section` function.