### PR TITLE
Add OS-specific `FLAG` statement

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -508,6 +508,18 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         }
         return;
     }
+    //os-specific extension flags
+    if(line_like("FLAG $name $string", tokens, state)) {
+        if(state.section_state != 0)
+            error("you can only use the FLAG statement before the DATA and PROCEDURE sections (\033[0m" + current_file + ":" + to_string(line_num)+"\033[1;31m)");
+        else {
+            if (tokens[1] == current_os()) {
+              string flag = tokens[2].substr(1, tokens[2].size() - 2);
+              extension_flags.push_back(flag);
+            }
+        }
+        return;
+    }
 
     // Sections
     if(line_like("DATA:", tokens, state))
@@ -2140,4 +2152,41 @@ void add_call_code(string & subprocedure, vector<string> & parameters, compiler_
     }
     code += ");";
     state.add_code(code);
+}
+
+// https://sourceforge.net/p/predef/wiki/OperatingSystems/
+string current_os() {
+#if defined(__linux__)
+  return "LINUX";
+#elif defined(__APPLE__)
+  return "MACOS";
+#elif defined(_WIN32)
+  return "WINDOWS";
+#elif defined(_MSC_VER)
+  return "MSVC";
+#elif defined(__FreeBSD__)
+  return "FREEBSD";
+#elif defined(__OpenBSD__)
+  return "OPENBSD";
+#elif defined(__NetBSD__)
+  return "NETBSD";
+#elif defined(__DragonFly__)
+  return "DRAGONFLY"; // ?
+#elif defined(__ANDROID__)
+  return "ANDROID";
+#elif defined(__GNU__)
+  return "HURD";
+#elif defined(_sun)
+  return "SOLARIS";
+#elif defined(EPLAN9)
+  return "PLAN9";
+#elif defined(__Fuchsia__)
+  return "FUCHSIA";
+#elif defined(__OS2__)
+  return "OS/2";
+#elif defined(__EMSCRIPTEN__)
+  return "EMSCRIPTEN";
+#else
+  return "UNKNOWN";
+#endif
 }

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -2160,7 +2160,7 @@ string current_os() {
     return "LINUX";
 #elif defined(__APPLE__)
     return "MACOS";
-#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || 
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
     return "BSD";
 #elif defined(__ANDROID__)
     return "ANDROID";

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -2157,36 +2157,16 @@ void add_call_code(string & subprocedure, vector<string> & parameters, compiler_
 // https://sourceforge.net/p/predef/wiki/OperatingSystems/
 string current_os() {
 #if defined(__linux__)
-  return "LINUX";
+    return "LINUX";
 #elif defined(__APPLE__)
-  return "MACOS";
-#elif defined(_WIN32)
-  return "WINDOWS";
-#elif defined(_MSC_VER)
-  return "MSVC";
-#elif defined(__FreeBSD__)
-  return "FREEBSD";
-#elif defined(__OpenBSD__)
-  return "OPENBSD";
-#elif defined(__NetBSD__)
-  return "NETBSD";
-#elif defined(__DragonFly__)
-  return "DRAGONFLY"; // ?
+    return "MACOS";
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || 
+    return "BSD";
 #elif defined(__ANDROID__)
-  return "ANDROID";
-#elif defined(__GNU__)
-  return "HURD";
-#elif defined(_sun)
-  return "SOLARIS";
-#elif defined(EPLAN9)
-  return "PLAN9";
-#elif defined(__Fuchsia__)
-  return "FUCHSIA";
-#elif defined(__OS2__)
-  return "OS/2";
+    return "ANDROID";
 #elif defined(__EMSCRIPTEN__)
-  return "EMSCRIPTEN";
+    return "EMSCRIPTEN";
 #else
-  return "UNKNOWN";
+    return "UNKNOWN";
 #endif
 }

--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -183,3 +183,4 @@ bool in_procedure_section(compiler_state & state, unsigned int line_num, string 
 vector<unsigned int> variable_type(string & token, compiler_state & state);
 void open_subprocedure_code(compiler_state & state, unsigned int line_num, string & current_file);
 void add_call_code(string & subprocedure, vector<string> & parameters, compiler_state & state, unsigned int line_num);
+string current_os();


### PR DESCRIPTION
As per the discussion on lartu/ldpl-ncurses#2, this adds support for an OS-specific version of the `FLAG` statement:

````coffeescript
extension "ldpl-ncurses.cpp"
flag "-O3"
flag linux "-lncursesw"
flag macos "-lncurses"
flag macos "-D_XOPEN_SOURCE_EXTENDED"
````

This will always pass `"-O3"` to the compiler (the same as how `FLAG` works today), but it will check the LDPL compiler's OS to determine whether to pass the additional flags.

The new statement uses the standard C/C++ macros listed at https://sourceforge.net/p/predef/wiki/OperatingSystems/ to detect which OS the user is running. These should be very resilient as they are what "regular" C and C++ programs use to do OS detection. As such, we will probably not need to change the current list but may need to add new entries as new platforms come into being and get supported by LDPL.

(We could also probably cut the list down to just the platforms we support, but, y'know, I wanted to give a shout out to OS/2 and DragonFlyBSD. Maybe PalmOS.)

I didn't add the `FLAG DEFAULT "-whatever"` functionality because this was simpler, but I could add it if we think it's needed. 