### PR TITLE
Experimental new nested type syntax.

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -587,23 +587,22 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
             if (extern_keyword == "") assign_default = " = \"\"";           // And if it's not external, we set it to a default value.
         } else if ((tokens[i]=="MAP"||tokens[i]=="LIST") && tokens.size() > i && tokens[i+1] == "OF") {
             // nested 'of' syntax, ex: map of list of number
-            vector<int> types;
             while (valid_type && i < tokens.size()) {
                 if (i % 2 == 1) {
                     if (tokens[i] != "OF")
                         valid_type = false;
                 } else if (i % 2 == 0) {
                     if (tokens[i] == "MAP") {
-                        types.push_back(4);
+                        type_number.push_back(4);
                     } else if (tokens[i] == "LIST") {
-                        types.push_back(3);
+                        type_number.push_back(3);
                     } else if (tokens.size()-1 > i) {
                         // text and number must be the final type listed
                         valid_type = false;
                     } else if (tokens[i] == "TEXT") {
-                        types.push_back(2);
+                        type_number.push_back(2);
                     } else if (tokens[i]=="NUMBER"||tokens[i]=="NUMBERS") {
-                        types.push_back(1);
+                        type_number.push_back(1);
                     } else {
                         valid_type = false;
                     }
@@ -612,23 +611,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
                 }
                 ++i;
             }
-            // declare types in reverse order, ex:
-            //   list of list of number -> ldpl_vector<ldpl_list<ldpl_number>>>
-            for (int z = types.size()-1; z >= 0; --z) {
-                if(!valid_type) break;
-                type_number.push_back(types[z]);
-                if (types[z] == 4) {
-                    type = "ldpl_vector<" + type + ">";
-                } else if (types[z] == 3) {
-                    type = "ldpl_list<" + type + ">";
-                } else if (types[z] == 2) {
-                    type = "chText";
-                } else if (types[z] == 1) {
-                    type = "ldpl_number";
-                } else {
-                    valid_type = false;
-                }
-            }
+            reverse(begin(type_number), end(type_number));
         } else {
             valid_type = false;                                             // If its not a NUMBER, a TEXT or a collection of these data types
         }                                                                   // then it's not a valid LDPL data type.


### PR DESCRIPTION
Just an idea I had, since the backwards nesting of multicontainer type names is a bit confusing to me.

What if instead of this:

````coffeescript
DATA:
  groceries IS number list
  names IS text map
````

you could do this:

````coffeescript
DATA:
  groceries IS list of numbers
  names IS map of text
````

And instead of this:

````coffeescript
DATA:
  myVariable is text list list
  myOtherVariable is number map list map map list map
  pleaseStop is text list list map list list map map map list map map list
````

You could, but should never, do this:

````coffeescript
DATA:
  myVariable is list of list of text
  myOtherVariable is map of list of map of map of list of map of number
  pleaseStop is list of map of map of list of map of map of map of list of list of map of list of list of text
````

This branch adds support for the nesting, keeping the current method for backwards compatability. 

Maybe a bit buggy, wanted to see if people thought this was an improvement before ironing it out. 