### PR TITLE
Support plural multicontainer type names

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -592,9 +592,9 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
                     if (tokens[i] != "OF")
                         valid_type = false;
                 } else if (i % 2 == 0) {
-                    if (tokens[i] == "MAP") {
+                    if (tokens[i] == "MAP"||(tokens[i] == "MAPS" && i>0)) {
                         type_number.push_back(4);
-                    } else if (tokens[i] == "LIST") {
+                    } else if (tokens[i] == "LIST"||(tokens[i] == "LISTS" && i>0)) {
                         type_number.push_back(3);
                     } else if (tokens.size()-1 > i) {
                         // text and number must be the final type listed


### PR DESCRIPTION
This adds support for using the plural version of type names in multicontainers.

For example, `list of maps of numbers` or `map of maps of lists of maps of text`.

The regular, non-plural type names are still supported, and the first container must always be singular (so you can't do `lists of text`, but you can do `list of lists of text`).