### PR TITLE
File error codes

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1120,9 +1120,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(!in_procedure_section(state, line_num, current_file))
             error("APPEND statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C++ Code
-        state.add_code("file_writing_stream.open(expandHomeDirectory(((chText)" + get_c_expression(state, tokens[4]) + ").str_rep()), ios_base::app);");
-        state.add_code("file_writing_stream <<" + get_c_expression(state, tokens[1]) + ";");
-        state.add_code("file_writing_stream.close();");
+        state.add_code("append_to_file(" + get_c_expression(state, tokens[4]) + ", " + get_c_expression(state, tokens[1]) + ");");
         return;
     }
 

--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -1110,9 +1110,7 @@ void compile_line(vector<string> & tokens, unsigned int line_num, compiler_state
         if(!in_procedure_section(state, line_num, current_file))
             error("WRITE statement outside PROCEDURE section (\033[0m" + current_file + ":"+ to_string(line_num)+"\033[1;31m)");
         //C++ Code
-        state.add_code("file_writing_stream.open(expandHomeDirectory(((chText)" + get_c_expression(state, tokens[4]) + ").str_rep()), ios_base::out);");
-        state.add_code("file_writing_stream <<" + get_c_expression(state, tokens[1]) + ";");
-        state.add_code("file_writing_stream.close();");
+        state.add_code("write_file(" + get_c_expression(state, tokens[4]) + ", " + get_c_expression(state, tokens[1]) + ");");
         return;
     }
     if(line_like("APPEND $expression TO FILE $str-expr", tokens, state))

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -783,22 +783,30 @@ void load_file(chText filename, chText & destination)
     file.close();
 }
 
-void append_to_file(chText filename, chText content){
-    file_writing_stream.open(expandHomeDirectory(filename.str_rep()), ios_base::app);
+// Used by append_ and write_.
+void stream_to_file(chText filename, chText content, ios_base::openmode mode){
+    file_writing_stream.open(expandHomeDirectory(filename.str_rep()), mode);
     if(!file_writing_stream.is_open()){
-        VAR_ERRORTEXT = \"Could not append to \" + filename;
+        VAR_ERRORTEXT = \"Could not write to \" + filename;
         VAR_ERRORCODE = 1;
         return;
     }
     file_writing_stream << content;
     if(file_writing_stream.bad()){
-        VAR_ERRORTEXT = \"Could not append to \" + filename;
+        VAR_ERRORTEXT = \"Could not write to \" + filename;
         VAR_ERRORCODE = 2;
         return;
     }
     VAR_ERRORTEXT = \"\";
     VAR_ERRORCODE = 0;
     file_writing_stream.close();
+}
+
+void append_to_file(chText filename, chText content){
+    stream_to_file(filename, content, ios_base::app);
+}
+void write_file(chText filename, chText content){
+    stream_to_file(filename, content, ios_base::out);
 }
 
 ldpl_number utf8GetIndexOf(chText haystack, chText needle){

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -783,6 +783,24 @@ void load_file(chText filename, chText & destination)
     file.close();
 }
 
+void append_to_file(chText filename, chText content){
+    file_writing_stream.open(expandHomeDirectory(filename.str_rep()), ios_base::app);
+    if(!file_writing_stream.is_open()){
+        VAR_ERRORTEXT = \"Could not append to \" + filename;
+        VAR_ERRORCODE = 1;
+        return;
+    }
+    file_writing_stream << content;
+    if(file_writing_stream.bad()){
+        VAR_ERRORTEXT = \"Could not append to \" + filename;
+        VAR_ERRORCODE = 2;
+        return;
+    }
+    VAR_ERRORTEXT = \"\";
+    VAR_ERRORCODE = 0;
+    file_writing_stream.close();
+}
+
 ldpl_number utf8GetIndexOf(chText haystack, chText needle){
     int lenHaystack = haystack.size();
     int lenNeedle = needle.size();

--- a/src/ldpl_lib.cpp
+++ b/src/ldpl_lib.cpp
@@ -784,10 +784,10 @@ void load_file(chText filename, chText & destination)
 }
 
 // Used by append_ and write_.
-void stream_to_file(chText filename, chText content, ios_base::openmode mode){
+void save_to_file(chText filename, chText content, ios_base::openmode mode){
     file_writing_stream.open(expandHomeDirectory(filename.str_rep()), mode);
     if(!file_writing_stream.is_open()){
-        VAR_ERRORTEXT = \"Could not write to \" + filename;
+        VAR_ERRORTEXT = \"Could not open \" + filename;
         VAR_ERRORCODE = 1;
         return;
     }
@@ -803,10 +803,10 @@ void stream_to_file(chText filename, chText content, ios_base::openmode mode){
 }
 
 void append_to_file(chText filename, chText content){
-    stream_to_file(filename, content, ios_base::app);
+    save_to_file(filename, content, ios_base::app);
 }
 void write_file(chText filename, chText content){
-    stream_to_file(filename, content, ios_base::out);
+    save_to_file(filename, content, ios_base::out);
 }
 
 ldpl_number utf8GetIndexOf(chText haystack, chText needle){


### PR DESCRIPTION
Attempts to address #169 by adding simple error codes (`1` and `2`) to `APPEND` and `WRITE`.

<strike>(I had trouble writing tests for this, need to find a surefire way to make these things fail.)</strike>

Edit: I just re-read the original issue, going to write a test for a protected file now.

Edit2: Basic tests are in https://github.com/Lartu/ldpltest/pull/20

🕺 