### PR TITLE
Convert #!/bin/bash to #!/usr/bin/env bash for consistency.

### DIFF
--- a/src/lib-to-string.sh
+++ b/src/lib-to-string.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 $(awk -f src/lib-to-string.awk src/ldpl_lib.cpp > src/ldpl_included_lib.cpp)
 exit 0


### PR DESCRIPTION
This allows the build to work on OpenBSD.