### PR TITLE
spelling mistake in documentation index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -108,7 +108,7 @@ the preferred extension couldn't be used for any reason.
 ## License
 
 This LDPL Compiler is distributed under the Apache 2.0 License.
-All LDPL Dinosaur logos where created by [Lartu](https://lartu.net) and are
+All LDPL Dinosaur logos were created by [Lartu](https://lartu.net) and are
 released under a Creative Commons Attribution 4.0 International (CC BY 4.0)
 license. This documentation is released under the Apache 2.0 License.
 


### PR DESCRIPTION
where -> were