### PR TITLE
ldpl -o=t -i=x should not crash

### DIFF
--- a/src/ldpl.cpp
+++ b/src/ldpl.cpp
@@ -105,7 +105,8 @@ int main(int argc, const char* argv[])
                 final_filename = arg.substr(3);
             }
             else if(arg.substr(0, 3) == "-i="){
-                if(0 == arg.compare(arg.length()-5, 5, ".ldpl")||0 == arg.compare(arg.length()-4, 4, ".lsc")){
+                if(((arg.length() > 5) && (0 == arg.compare(arg.length()-5, 5, ".ldpl")))
+                 ||((arg.length() > 4) && (0 == arg.compare(arg.length()-4, 4, ".lsc" )))){
                     if(files_to_compile.size() > 0){
                         warning("passing multiple LDPL source files to the\ncompiler is deprecated and may be removed in the future.\nPlease use the IMPORT statement instead.");
                     }


### PR DESCRIPTION
Very short filenames result in the following crash:

(gdb) frame 8
108	                if(0 == arg.compare(arg.length()-5, 5, ".ldpl")||0 == arg.compare(arg.length()-4, 4, ".lsc")){

With this patch, the shortest accepted filenames are ".ldpl" and ".lsc".

For shorter names we will get a cryptic error now:

LDPL Error: filename expected.