### PR TITLE
Update to fix install error

### DIFF
--- a/highlighting/gedit/install.sh
+++ b/highlighting/gedit/install.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-sudo cp ldpl.lang /usr/share/gtksourceview-3.0/language-specs/
+sudo cp ldpl.lang /usr/share/gtksourceview-4/language-specs/


### PR DESCRIPTION
This change fixes an error where the language file fails to install for Gedit 4 on Fedora 35. This reflects Gedit's move from GTK3 to GTK4.