### PR TITLE
Compilation error fix

### DIFF
--- a/src/ldpl.h
+++ b/src/ldpl.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <locale>
 #include <map>
+#include <memory>
 #include <queue>
 #include <sstream>
 #include <stack>


### PR DESCRIPTION
Interesting how nobody bothered to fix the simplest bug out there.
`unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);`
in line 37 needs the <memory> header in order to compile.