### PR TITLE
Added `CONVERT _ TO UPPERCASE/LOWERCASE IN _` statements

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -265,3 +265,44 @@ PROCEDURE:
 	# Will display "hello there!"
 ```
 
+## `CONVERT _ TO UPPERCASE IN _`
+
+The `CONVERT - TO UPPERCASE IN` statement converts all the characters in a string to uppercase and stores the resulting string in a TEXT variable.
+
+**Syntax:**
+
+```coffeescript
+CONVERT <TEXT or TEXT-VAR> TO UPPERCASE IN <TEXT-VAR>
+```
+
+**Example:**
+
+```coffeescript
+DATA:
+	greeting IS TEXT
+PROCEDURE:
+	CONVERT "hello there!" TO UPPERCASE IN greeting
+	DISPLAY greeting CRLF
+	# Will display "HELLO THERE!"
+```
+
+## `CONVERT _ TO LOWERCASE IN _`
+
+The `CONVERT - TO LOWERCASE IN` statement converts all the characters in a string to lowercase and stores the resulting string in a TEXT variable.
+
+**Syntax:**
+
+```coffeescript
+CONVERT <TEXT or TEXT-VAR> TO LOWERCASE IN <TEXT-VAR>
+```
+
+**Example:**
+
+```coffeescript
+DATA:
+	greeting IS TEXT
+PROCEDURE:
+	CONVERT "HELLO THERE!" TO LOWERCASE IN greeting
+	DISPLAY greeting CRLF
+	# Will display "hello there!"
+```

--- a/src/aux/aux_compile_line.cpp
+++ b/src/aux/aux_compile_line.cpp
@@ -867,6 +867,22 @@ void compile_line(vector<string> &tokens, compiler_state &state)
         state.add_code(get_c_variable(state, tokens[3]) + " = trimCopy(" + get_c_expression(state, tokens[1]) + ");", state.where);
         return;
     }
+    if (line_like("CONVERT $str-expr TO UPPERCASE IN $str-var", tokens, state))
+    {
+        if (!in_procedure_section(state))
+            badcode("CONVERT statement outside PROCEDURE section", state.where);
+        // C++ Code
+        state.add_code(get_c_variable(state, tokens[5]) + " = toUpperCopy(" + get_c_expression(state, tokens[1]) + ");", state.where);
+        return;
+    }
+    if (line_like("CONVERT $str-expr TO LOWERCASE IN $str-var", tokens, state))
+    {
+        if (!in_procedure_section(state))
+            badcode("CONVERT statement outside PROCEDURE section", state.where);
+        // C++ Code
+        state.add_code(get_c_variable(state, tokens[5]) + " = toLowerCopy(" + get_c_expression(state, tokens[1]) + ");", state.where);
+        return;
+    }
     if (line_like("CLEAR $collection", tokens, state))
     {
         if (!in_procedure_section(state))

--- a/src/ldpl_lib/ldpl_lib.cpp
+++ b/src/ldpl_lib/ldpl_lib.cpp
@@ -977,6 +977,22 @@ ldpl_number utf8Count(chText haystack, chText needle)
     return count;
 }
 
+//Converts string to uppercase
+chText toUpperCopy(chText str)
+{
+    string out = str.str_rep();
+    std::transform(out.begin(), out.end(), out.begin(), ::toupper);
+    return out;
+}
+
+//Converts string to lowercase
+chText toLowerCopy(chText str)
+{
+    string out = str.str_rep();
+    std::transform(out.begin(), out.end(), out.begin(), ::tolower);
+    return out;
+}
+
 //Removes all trailing and ending whitespace from a string
 chText trimCopy(chText _line)
 {


### PR DESCRIPTION
This is something else I uncovered while trying to convert compileman.php to LDPL: no uppercase/lowercase conversion in LDPL by default. I think it's handy to have these included in the language.

```coffeescript
DATA:
    input is text
    output is text

PROCEDURE:
    store "ldpl updates? great!" in input
    convert input to uppercase in output
    display "input: " input crlf
    display "output: " output crlf
```

```
$ ./example-bin
input: ldpl updates? great!
output: LDPL UPDATES? GREAT!
```