### PR TITLE
Added `REPLACE _ WITH _ FROM _ IN _`, deprecated old `REPLACE`

### DIFF
--- a/docs/text.md
+++ b/docs/text.md
@@ -28,7 +28,7 @@ will store
 in `myTextVariable`.
 
 
-## `REPLACE _ FROM _ WITH _ IN _`
+## `REPLACE _ WITH _ FROM _ IN _`
 
 
 The `REPLACE` statement finds and replaces every occurrence of some TEXT in a TEXT variable or value some other TEXT. The result is then stored in a TEXT variable.
@@ -36,7 +36,7 @@ The `REPLACE` statement finds and replaces every occurrence of some TEXT in a TE
 **Syntax:**
 
 ```coffeescript
-REPLACE <TEXT-VAR or TEXT> FROM <TEXT-VAR or TEXT> WITH <TEXT-VAR or TEXT> IN <TEXT-VAR>
+REPLACE <TEXT-VAR or TEXT> WITH <TEXT-VAR or TEXT> FROM <TEXT-VAR or TEXT> IN <TEXT-VAR>
 ```
 
 **Example:**

--- a/src/aux/aux_compile_line.cpp
+++ b/src/aux/aux_compile_line.cpp
@@ -826,6 +826,15 @@ void compile_line(vector<string> &tokens, compiler_state &state)
         return;
     }
 
+    if (line_like("REPLACE $str-expr WITH $str-expr FROM $str-expr IN $str-var", tokens, state))
+    {
+        if (!in_procedure_section(state))
+            badcode("REPLACE statement outside PROCEDURE section", state.where);
+        // C++ Code
+        state.add_code(get_c_variable(state, tokens[7]) + " = str_replace(((chText)" + get_c_expression(state, tokens[5]) + ").str_rep(), ((chText)" + get_c_expression(state, tokens[1]) + ").str_rep(), ((chText)" + get_c_expression(state, tokens[3]) + ").str_rep());", state.where);
+        return;
+    }
+    //deprecated
     if (line_like("REPLACE $str-expr FROM $str-expr WITH $str-expr IN $str-var", tokens, state))
     {
         if (!in_procedure_section(state))


### PR DESCRIPTION
Adds new ChatGPT-approved `REPLACE` syntax for #212 